### PR TITLE
Addition of "application" of parameters

### DIFF
--- a/include/pflib/Compile.h
+++ b/include/pflib/Compile.h
@@ -8,6 +8,21 @@
 namespace pflib {
 
 /**
+ * Get an integer from the input string
+ *
+ * The normal stoi (and similar) tools don't support binary inputs
+ * which are helpful in our case where sometimes the value is set
+ * in binary but each bit has a non-base-2 scale.
+ *
+ * Supported prefixes:
+ *  0b --> binary
+ *  0x --> hexidecimal
+ *  0  --> octal
+ *  none of the above --> decimal
+ */
+int str_to_int(std::string str);
+
+/**
  * Overlay a single parameter onto the input register map.
  * This only overwrites the bits that need to be changed
  * for the input parameter. Any registers that don't exist

--- a/include/pflib/Compile.h
+++ b/include/pflib/Compile.h
@@ -8,6 +8,14 @@
 namespace pflib {
 
 /**
+ * Compile a single parameter into the (potentially several)
+ * registers that it should set. Any other bits in the register(s)
+ * that this parameter affects will be set to zero.
+ */
+std::map<int,std::map<int,uint8_t>>
+compile(const std::string& page_name, const std::string& param_name, int val);
+
+/**
  * Compiling which translates parameter values for the HGCROC
  * into register values that can be written to the chip
  *

--- a/include/pflib/Compile.h
+++ b/include/pflib/Compile.h
@@ -8,12 +8,28 @@
 namespace pflib {
 
 /**
+ * Overlay a single parameter onto the input register map.
+ * This only overwrites the bits that need to be changed
+ * for the input parameter. Any registers that don't exist
+ * will be set to 0 before being written to.
+ *
+ * implementation of compiling a single value for the input parameter specification
+ * into the list of registers.
+ *
+ * This accesses the PARAMETER_LUT map, its submaps, and the register_values map without
+ * any checks so it may throw a std::out_of_range error. Do checking of names
+ * before calling this one.
+ */
+void compile(const std::string& page, const std::string& param, const int& val,
+    std::map<int,std::map<int,uint8_t>>& registers);
+
+/**
  * Compile a single parameter into the (potentially several)
  * registers that it should set. Any other bits in the register(s)
  * that this parameter affects will be set to zero.
  */
 std::map<int,std::map<int,uint8_t>>
-compile(const std::string& page_name, const std::string& param_name, int val);
+compile(const std::string& page_name, const std::string& param_name, const int& val);
 
 /**
  * Compiling which translates parameter values for the HGCROC

--- a/include/pflib/Compile.h
+++ b/include/pflib/Compile.h
@@ -85,6 +85,12 @@ compile(const std::map<std::string,std::map<std::string,int>>& settings);
 std::map<std::string,std::map<std::string,int>>
 decompile(const std::map<int,std::map<int,uint8_t>>& compiled_config);
 
+/**
+ * Extract the page name, parameter name, and parameter values from
+ * the YAML files into the passed settings map
+ */
+void extract(const std::vector<std::string>& setting_files, 
+    std::map<std::string,std::map<std::string,int>>& settings);
  
 /**
  * Compile a series of yaml files

--- a/include/pflib/PolarfireTarget.h
+++ b/include/pflib/PolarfireTarget.h
@@ -74,23 +74,28 @@ struct PolarfireTarget {
    *
    * @return false if unable to open file
    */
-  bool loadIntegerCSV(const std::string& file_name, 
+  void loadIntegerCSV(const std::string& file_name, 
       const std::function<void(const std::vector<int>&)>& Action);
 
   /**
-   * ## Files ending in .csv
+   * Load register values onto ROC chip from inptu file
+   *
    * Defines an Action with calls ROC::setValue if there
    * are three cells and prints a warning otherwise.
    *
-   * ## Files ending in .yaml or .yml
-   * Prints a not-implemented error.
-   *
-   * ## Other extensions
-   * Prints a error.
+   * @return false if unable to open file
+   */
+  void loadROCRegisters(int roc, const std::string& file_name);
+
+  /**
+   * Compile the input YAML file including the defaults
+   * if prepend_defaults is true, otherwise using current
+   * ROC settings  as "base" settings, then writes register
+   * values onto chip.
    *
    * @return false if unable to open file
    */
-  bool loadROCSettings(int roc, const std::string& file_name);
+  void loadROCParameters(int roc, const std::string& file_name, bool prepend_defaults);
 
   /**
    * Request all of the ROC setting register values
@@ -99,7 +104,7 @@ struct PolarfireTarget {
    * to be "decompiled", i.e. the the registr values are
    * unpacked into the parameter values.
    */
-  bool dumpSettings(int roc, const std::string& file_name, bool decompile);
+  void dumpSettings(int roc, const std::string& file_name, bool decompile);
 
   void prepareNewRun();
 

--- a/include/pflib/ROC.h
+++ b/include/pflib/ROC.h
@@ -6,10 +6,10 @@
 
 namespace pflib {
 
-  /**
-   * @class ROC setup
-   *
-   */
+/**
+ * @class ROC setup
+ *
+ */
 class ROC {
  public:
   ROC(I2C& i2c, int ibus=0);
@@ -19,6 +19,8 @@ class ROC {
   
   std::vector<uint8_t> getChannelParameters(int ichan);
   void setChannelParameters(int ichan, std::vector<uint8_t>& values);
+
+  void applyParameter(const std::string& page, const std::string& param, const int& val);
 
 
  private:

--- a/include/pflib/ROC.h
+++ b/include/pflib/ROC.h
@@ -3,6 +3,8 @@
 
 #include "pflib/I2C.h"
 #include <vector>
+#include <map>
+#include <string>
 
 namespace pflib {
 
@@ -20,6 +22,10 @@ class ROC {
   std::vector<uint8_t> getChannelParameters(int ichan);
   void setChannelParameters(int ichan, std::vector<uint8_t>& values);
 
+  void setRegisters(const std::map<int,std::map<int,uint8_t>>& registers);
+  void applyParameters(const std::map<std::string,std::map<std::string,int>>& parameters);
+
+  // short-hand for just applying a single parameter
   void applyParameter(const std::string& page, const std::string& param, const int& val);
 
 

--- a/src/pflib/Compile.cxx
+++ b/src/pflib/Compile.cxx
@@ -525,19 +525,8 @@ void apply(YAML::Node params, std::map<std::string,std::map<std::string,int>>& s
 
 } // namespace detail
 
-std::map<int,std::map<int,uint8_t>> 
-compile(const std::vector<std::string>& setting_files, bool prepend_defaults) {
-  // if we prepend the defaults, put all settings and their defaults 
-  // into the settings map
-  std::map<std::string,std::map<std::string,int>> settings;
-  if (prepend_defaults) {
-    for(auto& page : PARAMETER_LUT) {
-      for (auto& param : page.second.second) {
-        settings[page.first][param.first] = param.second.def;
-      }
-    }
-  }
-
+void extract(const std::vector<std::string>& setting_files,
+    std::map<std::string,std::map<std::string,int>>& settings) {
   for (auto& setting_file : setting_files) {
     YAML::Node setting_yaml;
     try {
@@ -551,7 +540,21 @@ compile(const std::vector<std::string>& setting_files, bool prepend_defaults) {
       detail::apply(setting_yaml, settings);
     }
   }
+}
 
+std::map<int,std::map<int,uint8_t>> 
+compile(const std::vector<std::string>& setting_files, bool prepend_defaults) {
+  std::map<std::string,std::map<std::string,int>> settings;
+  // if we prepend the defaults, put all settings and their defaults 
+  // into the settings map before extraction
+  if (prepend_defaults) {
+    for(auto& page : PARAMETER_LUT) {
+      for (auto& param : page.second.second) {
+        settings[page.first][param.first] = param.second.def;
+      }
+    }
+  }
+  extract(setting_files,settings);
   return compile(settings);
 }
 

--- a/src/pflib/Compile.cxx
+++ b/src/pflib/Compile.cxx
@@ -351,6 +351,27 @@ PARAMETER_LUT = {
   {"Channel_71", {37, CHANNEL_WISE_LUT}}
 };
 
+int str_to_int(std::string str) {
+  if (str == "0") return 0;
+  int base = 10;
+  if (str[0] == '0' and str.length() > 2) {
+    // binary or hexadecimal
+    if (str[1] == 'b' or str[1] == 'B') {
+      base = 2;
+      str = str.substr(2);
+    } else if (str[1] == 'x' or str[1] == 'X') {
+      base = 16;
+      str = str.substr(2);
+    } 
+  } else if (str[0] == '0' and str.length() > 1) {
+    // octal
+    base = 8;
+    str = str.substr(1);
+  }
+
+  return std::stoi(str,nullptr,base);
+}
+
 void compile(const std::string& page_name, const std::string& param_name, const int& val, 
     std::map<int,std::map<int,uint8_t>>& register_values) {
   const auto& page_id {PARAMETER_LUT.at(page_name).first};
@@ -496,18 +517,7 @@ void apply(YAML::Node params, std::map<std::string,std::map<std::string,int>>& s
           PFEXCEPTION_RAISE("BadFormat",
               "Non-existent value for parameter "+param.first.as<std::string>());
         }
-        int base = 10;
-        if (sval[0] == '0') {
-          if (sval[1] == 'b' or sval[1] == 'B') {
-            base = 2;
-            sval = sval.substr(2);
-          } else if (sval[1] == 'x' or sval[1] == 'X') {
-            base = 16;
-            sval = sval.substr(2);
-          }
-        }
-        settings[page][param.first.as<std::string>()] 
-          = std::stoi(sval,nullptr,base);
+        settings[page][param.first.as<std::string>()] = str_to_int(sval);
       }
     }
   }

--- a/tool/pftool.cc
+++ b/tool/pftool.cc
@@ -256,7 +256,8 @@ uMenu::Line menu_ldmx_roc_lines[] =
    uMenu::Line("IROC","Change the active ROC number", &ldmx_roc ),
    uMenu::Line("CHAN","Dump link status", &ldmx_roc ),
    uMenu::Line("PAGE","Dump a page", &ldmx_roc ),
-   uMenu::Line("POKE","Change a single value", &ldmx_roc ),
+   uMenu::Line("POKE_REG","Change a single register value", &ldmx_roc ),
+   uMenu::Line("POKE_PARAM","Change a single parameter value", &ldmx_roc ),
    uMenu::Line("LOAD","Load values from file", &ldmx_roc ),
    uMenu::Line("DUMP","Dump hgcroc settings to a file", &ldmx_roc ),
    uMenu::Line("QUIT","Back to top menu"),
@@ -587,12 +588,23 @@ void ldmx_roc( const std::string& cmd, PolarfireTarget* pft ) {
     for (int i=0; i<int(v.size()); i++)
       printf("%02d : %02x\n",i,v[i]);
   }
-  if (cmd=="POKE") {
+  if (cmd=="POKE_REG") {
     int page=BaseMenu::readline_int("Which page? ",0);
     int entry=BaseMenu::readline_int("Offset: ",0);
     int value=BaseMenu::readline_int("New value: ",0);
-
+  
     roc.setValue(page,entry,value);
+  }
+  if (cmd=="POKE_PARAM") {
+    std::string page = BaseMenu::readline("Page: ", "Global_Analog_0");
+    std::string param = BaseMenu::readline("Parameter: ");
+    int val = BaseMenu::readline_int("New value: ", 0);
+
+    try {
+      roc.applyParameter(page, param, val);
+    } catch (const pflib::Exception& e) {
+      std::cerr << "\n ERROR: [" << e.name() << "] : " << e.message() << std::endl;
+    }
   }
   if (cmd=="LOAD") {
     printf("\n --- This command expects a CSV file with columns [page,offset,value].\n");

--- a/tool/pftool.cc
+++ b/tool/pftool.cc
@@ -11,6 +11,7 @@
 #include <string>
 #include <exception>
 #include "pflib/PolarfireTarget.h"
+#include "pflib/Compile.h" // for str_to_int
 #ifdef PFTOOL_ROGUE
 #include "pflib/rogue/RogueWishboneInterface.h"
 #endif
@@ -591,14 +592,14 @@ void ldmx_roc( const std::string& cmd, PolarfireTarget* pft ) {
   if (cmd=="POKE_REG") {
     int page=BaseMenu::readline_int("Which page? ",0);
     int entry=BaseMenu::readline_int("Offset: ",0);
-    int value=BaseMenu::readline_int("New value: ",0);
+    int value=pflib::str_to_int(BaseMenu::readline("New value: "));
   
     roc.setValue(page,entry,value);
   }
   if (cmd=="POKE_PARAM") {
     std::string page = BaseMenu::readline("Page: ", "Global_Analog_0");
     std::string param = BaseMenu::readline("Parameter: ");
-    int val = BaseMenu::readline_int("New value: ", 0);
+    int val =pflib::str_to_int(BaseMenu::readline("New value: "));
 
     try {
       roc.applyParameter(page, param, val);

--- a/tool/pftool.cc
+++ b/tool/pftool.cc
@@ -603,11 +603,7 @@ void ldmx_roc( const std::string& cmd, PolarfireTarget* pft ) {
     std::string param = BaseMenu::readline("Parameter: ");
     int val =pflib::str_to_int(BaseMenu::readline("New value: "));
 
-    try {
-      roc.applyParameter(page, param, val);
-    } catch (const pflib::Exception& e) {
-      std::cerr << "\n ERROR: [" << e.name() << "] : " << e.message() << std::endl;
-    }
+    roc.applyParameter(page, param, val);
   }
   if (cmd=="LOAD_REG") {
     std::cout <<
@@ -615,11 +611,7 @@ void ldmx_roc( const std::string& cmd, PolarfireTarget* pft ) {
       " --- This command expects a CSV file with columns [page,offset,value].\n"
       << std::flush;
     std::string fname = BaseMenu::readline("Filename: ");
-    try {
-      pft->loadROCRegisters(iroc,fname);
-    } catch (const pflib::Exception& e) {
-      std::cerr << "\n ERROR: [" << e.name() << "] : " << e.message() << std::endl;
-    }
+    pft->loadROCRegisters(iroc,fname);
   }
   if (cmd=="LOAD"||cmd=="LOAD_PARAM") {
     std::cout <<
@@ -628,11 +620,7 @@ void ldmx_roc( const std::string& cmd, PolarfireTarget* pft ) {
       << std::flush;
     std::string fname = BaseMenu::readline("Filename: ");
     bool prepend_defaults = BaseMenu::readline_bool("Update all parameter values on the chip using the defaults in the manual for any values not provided? ", false);
-    try {
-      pft->loadROCParameters(iroc,fname,prepend_defaults);
-    } catch (const pflib::Exception& e) {
-      std::cerr << "\n ERROR: [" << e.name() << "] : " << e.message() << std::endl;
-    }
+    pft->loadROCParameters(iroc,fname,prepend_defaults);
   }
   if (cmd=="DUMP") {
     std::string fname_def_format = "hgcroc_"+std::to_string(iroc)+"_settings_%Y%m%d_%H%M%S.yaml";
@@ -645,11 +633,7 @@ void ldmx_roc( const std::string& cmd, PolarfireTarget* pft ) {
     
     std::string fname = BaseMenu::readline("Filename: ", fname_def);
 	  bool decompile = BaseMenu::readline_bool("Decompile register values? ",true);
-    try {
-      pft->dumpSettings(iroc,fname,decompile);
-    } catch (const pflib::Exception& e) {
-      std::cerr << "\n ERROR: [" << e.name() << "] : " << e.message() << std::endl;
-    }
+    pft->dumpSettings(iroc,fname,decompile);
   }
 }
 

--- a/tool/pftool.cc
+++ b/tool/pftool.cc
@@ -259,6 +259,7 @@ uMenu::Line menu_ldmx_roc_lines[] =
    uMenu::Line("PAGE","Dump a page", &ldmx_roc ),
    uMenu::Line("POKE_REG","Change a single register value", &ldmx_roc ),
    uMenu::Line("POKE_PARAM","Change a single parameter value", &ldmx_roc ),
+   uMenu::Line("POKE","Alias for POKE_PARAM", &ldmx_roc ),
    uMenu::Line("LOAD_REG","Load register values onto the chip from a CSV file", &ldmx_roc ),
    uMenu::Line("LOAD_PARAM","Load parameter values onto the chip from a YAML file", &ldmx_roc ),
    uMenu::Line("LOAD","Alias for LOAD_PARAM", &ldmx_roc ),
@@ -564,7 +565,6 @@ void ldmx_roc_render(PolarfireTarget*) {
 }
 
 void ldmx_roc( const std::string& cmd, PolarfireTarget* pft ) {
-
   if (cmd=="HARDRESET") {
     pft->hcal->hardResetROCs();
   }
@@ -598,7 +598,7 @@ void ldmx_roc( const std::string& cmd, PolarfireTarget* pft ) {
   
     roc.setValue(page,entry,value);
   }
-  if (cmd=="POKE_PARAM") {
+  if (cmd=="POKE"||cmd=="POKE_PARAM") {
     std::string page = BaseMenu::readline("Page: ", "Global_Analog_0");
     std::string param = BaseMenu::readline("Parameter: ");
     int val =pflib::str_to_int(BaseMenu::readline("New value: "));


### PR DESCRIPTION
In this, I use "application" to signal that the parameters are put on top of the current chip configuration. This added ability is necessary for things like scans (#6 ) where we want the configuration to stay the same except for one parameter changing. Moreover, it is helpful for the pftool to be able to modify the configuration one step at a time during testing.

The application still retains the ability to set all of the parameters at once. This process is started by using the defaults documented in the HGC ROC manual and then applying the parameters provided by the user on top of that.

**Note**: The "defaults" from the manual are not necessarily the same as the power-on defaults.