### PR TITLE
New relink

### DIFF
--- a/include/pflib/PolarfireTarget.h
+++ b/include/pflib/PolarfireTarget.h
@@ -216,6 +216,8 @@ struct PolarfireTarget {
 
   /** Carries out the standard elink alignment process */
   void elink_relink(int verbosity);
+
+  void bitslip();
   
  private:
   int samples_per_event_;  

--- a/include/pflib/PolarfireTarget.h
+++ b/include/pflib/PolarfireTarget.h
@@ -215,9 +215,11 @@ struct PolarfireTarget {
   bool loadBiasSettings(const std::string& file_name);
 
   /** Carries out the standard elink alignment process */
-  void elink_relink(int verbosity);
+  void elink_relink(int ilink,int verbosity);
 
-  void bitslip();
+  void delay_loop(int ilink);
+
+  bool bitslip_loop(int ilink);
   
  private:
   int samples_per_event_;  

--- a/src/pflib/PolarfireTarget.cxx
+++ b/src/pflib/PolarfireTarget.cxx
@@ -443,19 +443,25 @@ bool PolarfireTarget::loadBiasSettings(const std::string& file_name) {
 void PolarfireTarget::elink_relink(int ilink ,int verbosity) {
   pflib::Elinks& elinks=hcal.elinks();
 
-  delay_loop(ilink);
+  if (ilink == -1){
+    for (int ilink=0; ilink<elinks.nlinks(); ilink++) {
+      delay_loop(ilink);
+    }
+  } else delay_loop(ilink);
 
 }
 
 void PolarfireTarget::delay_loop(int ilink){
-  pflib::Elinks& elinks=hcal.elinks();
+  pflib::Elinks& elinks = hcal.elinks();
+  bool passedBitslipLoop = false;
   if (elinks.isActive(ilink)){
     for (int delay=20; delay<26; delay++){
       elinks.setDelay(ilink,delay);
-       if (bitslip_loop(ilink)) break;
+      passedBitslipLoop = bitslip_loop(ilink);
+       if (passedBitslipLoop) break;
     }
-  }
-
+    if (!passedBitslipLoop) printf("Delay scan exceeded 25, you should do an elinks hardreset\n");
+  } else printf("    Elink %d is not active.\n",ilink);
 }
 
 bool PolarfireTarget::bitslip_loop(int ilink){

--- a/src/pflib/PolarfireTarget.cxx
+++ b/src/pflib/PolarfireTarget.cxx
@@ -453,13 +453,19 @@ void PolarfireTarget::elink_relink(int verbosity) {
   if (verbosity>0) {
     printf("...Hard reset\n");
   }
-  elinks.resetHard();
-  sleep(1);
+  //elinks.resetHard();
+  //sleep(1);
   
   if (verbosity>0) {
     printf("...Scanning bitslip values\n");
   }
 
+  bitslip();
+
+}
+
+void PolarfireTarget::bitslip(){
+  pflib::Elinks& elinks=hcal.elinks();
   for (int ilink=0; ilink<elinks.nlinks(); ilink++) {
     if (!elinks.isActive(ilink)) continue;
     

--- a/src/pflib/PolarfireTarget.cxx
+++ b/src/pflib/PolarfireTarget.cxx
@@ -440,61 +440,59 @@ bool PolarfireTarget::loadBiasSettings(const std::string& file_name) {
   }
 }
 
-void PolarfireTarget::elink_relink(int verbosity) {
+void PolarfireTarget::elink_relink(int ilink ,int verbosity) {
   pflib::Elinks& elinks=hcal.elinks();
 
-  if (verbosity>0) 
-    printf("...Setting phase delays\n");    
-  for (int ilink=0; ilink<elinks.nlinks(); ilink++) 
-    if (elinks.isActive(ilink)) 
-      elinks.setDelay(ilink,20);
-
-  
-  if (verbosity>0) {
-    printf("...Hard reset\n");
-  }
-  //elinks.resetHard();
-  //sleep(1);
-  
-  if (verbosity>0) {
-    printf("...Scanning bitslip values\n");
-  }
-
-  bitslip();
+  delay_loop(ilink);
 
 }
 
-void PolarfireTarget::bitslip(){
+void PolarfireTarget::delay_loop(int ilink){
   pflib::Elinks& elinks=hcal.elinks();
-  for (int ilink=0; ilink<elinks.nlinks(); ilink++) {
-    if (!elinks.isActive(ilink)) continue;
-    
-    elinks.setBitslipAuto(ilink,false);
-    
-    int okcount[8];
-    
-    for (int slip=0; slip<8; slip++) {
-      elinks.setBitslip(ilink,slip);
-      okcount[slip]=0;
-      for (int cycles=0; cycles<5; cycles++) {
-        std::vector<uint8_t> spy=elinks.spy(ilink);
-        for (size_t i=0; i+4<spy.size(); ) {
-          if (spy[i]==0x9c || spy[i]==0xac) {
-            if (spy[i+1]==0xcc && spy[i+2]==0xcc && spy[i+3]==0xcc) okcount[slip]++;
-            i+=4;
-          } else i++;
-        } 
-      }
+  if (elinks.isActive(ilink)){
+    for (int delay=20; delay<26; delay++){
+      elinks.setDelay(ilink,delay);
+       if (bitslip_loop(ilink)) break;
     }
-    int imax=-1;
-    for (int slip=0; slip<8; slip++) {
-      if (imax<0 || okcount[slip]>okcount[imax]) imax=slip;
-    }
-    elinks.setBitslip(ilink,imax);
-    printf("    Link %d bitslip %d  (ok count=%d)\n",ilink,imax,okcount[imax]);
   }
-  
+
 }
+
+bool PolarfireTarget::bitslip_loop(int ilink){
+  pflib::Elinks& elinks=hcal.elinks();
+    
+  elinks.setBitslipAuto(ilink,false);
+    
+  int okcount[8];
+    
+  for (int slip=0; slip<8; slip++) {
+    elinks.setBitslip(ilink,slip);
+    okcount[slip]=0;
+    for (int cycles=0; cycles<5; cycles++) {
+      std::vector<uint8_t> spy=elinks.spy(ilink);
+      for (size_t i=0; i+4<spy.size(); ) {
+        if (spy[i]==0x9c || spy[i]==0xac) {
+          if (spy[i+1]==0xcc && spy[i+2]==0xcc && spy[i+3]==0xcc) okcount[slip]++;
+          i+=4;
+        } else i++;
+      } 
+    }
+  }
+  int imax=-1;
+  for (int slip=0; slip<8; slip++) {
+    if (imax<0 || okcount[slip]>okcount[imax]) imax=slip;
+  }
+  elinks.setBitslip(ilink,imax);
+  printf("    Link %d bitslip %d  (ok count=%d)\n",ilink,imax,okcount[imax]);
+
+  if (okcount[imax] == 75){
+    return true;
+  }
+  else return false;
+
+}
+  
+//}
 
   
 

--- a/tool/pftool.cc
+++ b/tool/pftool.cc
@@ -240,7 +240,7 @@ static void elinks( const std::string& cmd, PolarfireTarget* pft ) {
   pflib::Elinks& elinks=pft->hcal.elinks();
   static int ilink=0;
   if (cmd=="RELINK"){
-    ilink=BaseMenu::readline_int("Which elink? ",ilink);
+    ilink=BaseMenu::readline_int("Which elink? (-1 for all) ",ilink);
     pft->elink_relink(ilink,2);
   }
   if (cmd=="SPY") {

--- a/tool/pftool.cc
+++ b/tool/pftool.cc
@@ -239,8 +239,10 @@ static void link( const std::string& cmd, PolarfireTarget* pft ) {
 static void elinks( const std::string& cmd, PolarfireTarget* pft ) {
   pflib::Elinks& elinks=pft->hcal.elinks();
   static int ilink=0;
-  if (cmd=="RELINK")
-    pft->elink_relink(2);
+  if (cmd=="RELINK"){
+    ilink=BaseMenu::readline_int("Which elink? ",ilink);
+    pft->elink_relink(ilink,2);
+  }
   if (cmd=="SPY") {
     ilink=BaseMenu::readline_int("Which elink? ",ilink);
     std::vector<uint8_t> spy=elinks.spy(ilink);


### PR DESCRIPTION
Made changes to the Relink procedure. The user can select a specific elink to relink, or select -1 for all. The relink procedure then loops over delays 20-25, and for each delay finds the appropriate bitslip. If the spy on the elink is not successful 75 times, the procedure does not stop, but instead the delay is incremented and the bitslip is tested again. Hard reset has been removed from the relink procedure, and the user is instead reminded to do a hard reset of the elinks if the procedure does not converge.

I put the bitslip and delay loops in separate functions, if this or any naming convention is undesired, please let me know