### PR TITLE
Specify board specific config files in pftoolrc

### DIFF
--- a/include/pflib/PolarfireTarget.h
+++ b/include/pflib/PolarfireTarget.h
@@ -4,6 +4,7 @@
 #include <ostream>
 #include <memory>
 #include <functional>
+#include <string>
 
 #include "pflib/WishboneInterface.h"
 #include "pflib/Backend.h"
@@ -144,6 +145,16 @@ struct PolarfireTarget {
   void loadROCParameters(int roc, const std::string& file_name, bool prepend_defaults);
 
   /**
+   * Stores paths of default ROC config files, as given by the pftoolrc
+   */
+  void findDefaultROCParameters(std::vector<std::string> paths);
+
+  /**
+   * Loads the default ROC config on boards where it is specified
+   */
+  void loadDefaultROCParameters();
+
+  /**
    * Request all of the ROC setting register values
    *
    * The input lets you choose if you want the output
@@ -218,7 +229,8 @@ struct PolarfireTarget {
   void elink_relink(int verbosity);
   
  private:
-  int samples_per_event_;  
+  int samples_per_event_;
+  std::vector<std::string> default_configs_;
 };
 
 }

--- a/src/pflib/PolarfireTarget.cxx
+++ b/src/pflib/PolarfireTarget.cxx
@@ -11,6 +11,7 @@
 #include <iomanip>
 #include <fstream>
 #include <unistd.h>
+#include <string>
 
 #include <yaml-cpp/yaml.h>
 
@@ -190,6 +191,22 @@ void PolarfireTarget::loadROCParameters(int roc, const std::string& file_name, b
     std::map<std::string,std::map<std::string,int>> parameters;
     extract(std::vector<std::string>{file_name}, parameters);
     hcal.roc(roc).applyParameters(parameters);
+  }
+}
+
+void PolarfireTarget::findDefaultROCParameters(std::vector<std::string> paths) {
+  default_configs_ = paths;
+}
+
+void PolarfireTarget::loadDefaultROCParameters() {
+  for(int i = 0; i < default_configs_.size(); i++){
+    if(default_configs_.at(i) == ""){
+      std::cout << "Skipping board " << i << std::endl;
+    }
+    else{
+      std::cout << "Loading config " << default_configs_.at(i) << " on ROC " << i << std::endl;
+      loadROCParameters(i, default_configs_.at(i), false);
+    }
   }
 }
 

--- a/tool/pftool.cc
+++ b/tool/pftool.cc
@@ -398,6 +398,9 @@ static void roc( const std::string& cmd, PolarfireTarget* pft ) {
     bool prepend_defaults = BaseMenu::readline_bool("Update all parameter values on the chip using the defaults in the manual for any values not provided? ", false);
     pft->loadROCParameters(iroc,fname,prepend_defaults);
   }
+  if (cmd=="DEFAULT_PARAMS") {
+    pft->loadDefaultROCParameters();
+  }
   if (cmd=="DUMP") {
     std::string fname_def_format = "hgcroc_"+std::to_string(iroc)+"_settings_%Y%m%d_%H%M%S.yaml";
 
@@ -1069,6 +1072,7 @@ static void RunMenu( PolarfireTarget* pft_ ) {
      pfMenu::Line("LOAD_PARAM","Load parameter values onto the chip from a YAML file", &roc ),
      pfMenu::Line("LOAD","Alias for LOAD_PARAM", &roc ),
      pfMenu::Line("DUMP","Dump hgcroc settings to a file", &roc ),
+     pfMenu::Line("DEFAULT_PARAMS", "Load default YAML files", &roc),
      pfMenu::Line("QUIT","Back to top menu")
     }, roc_render);
   
@@ -1180,6 +1184,7 @@ void prepareOpts(Rcfile& rcfile) {
       "Full path to directory containgin IP-bus mapping. Only required for uHal comm.");
   rcfile.declareString("default_hostname",
       "Hostname of polarfire to connect to if none are given on the command line");
+  rcfile.declareVString("roc_configs", "Vector String[4] pointing to default .yaml configs for each roc");
 }
 
 /**
@@ -1317,6 +1322,9 @@ int main(int argc, char* argv[]) {
     }
   }
 
+  //if (options.contents().is_vector("roclinks")) {
+  //        std::vector<bool> actives=options.contents().getVBool("roclinks");
+
   /*****************************************************************************
    * Run tool
    ****************************************************************************/
@@ -1373,6 +1381,11 @@ int main(int argc, char* argv[]) {
               ilink<p_pft->hcal.elinks().nlinks() and ilink<int(actives.size()); 
               ilink++) p_pft->hcal.elinks().markActive(ilink,actives[ilink]);
       	}
+
+        if (options.contents().is_vector("roc_configs")) {
+          p_pft->findDefaultROCParameters(options.contents().getVString("roc_configs"));
+        }
+
         status(p_pft.get());
         RunMenu(p_pft.get());
       } else {

--- a/tool/pftool.cc
+++ b/tool/pftool.cc
@@ -1322,9 +1322,6 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  //if (options.contents().is_vector("roclinks")) {
-  //        std::vector<bool> actives=options.contents().getVBool("roclinks");
-
   /*****************************************************************************
    * Run tool
    ****************************************************************************/


### PR DESCRIPTION
Solves issue #47  

One can now specify board specific config files in pftoolrc and load these with ROC->DEFAULT_PARAMS. This is so shifters won't have to manually load specific config files on different boards. 

Currently Rcfile options are not passed through to the menus, and I didn't know whether that was desirable, so I settled with making the PolarfireTarget instance save where the default config files lie. 