### PR TITLE
Add some fast control functionality from tb into uHAL

### DIFF
--- a/include/pflib/uhal/uhalWishboneInterface.h
+++ b/include/pflib/uhal/uhalWishboneInterface.h
@@ -60,7 +60,6 @@ class uhalWishboneInterface : public WishboneInterface, public Backend {
   virtual void fc_setup_calib(int pulse_len, int l1a_offset);
   virtual void fc_get_setup_calib(int& pulse_len, int& l1a_offset);
   virtual void fc_read_counters(int&  spill_count, int& header_occ, int& header_occ_max, int& event_count, int& vetoed_counter) override;
-
   virtual void fc_clear_run() override;
   virtual void fc_advance_l1_fifo() override;
   virtual void fc_enables_read(bool& ext_l1a, bool& ext_spill, bool& timer_l1a) override;

--- a/include/pflib/uhal/uhalWishboneInterface.h
+++ b/include/pflib/uhal/uhalWishboneInterface.h
@@ -59,6 +59,15 @@ class uhalWishboneInterface : public WishboneInterface, public Backend {
   virtual void fc_calibpulse();
   virtual void fc_setup_calib(int pulse_len, int l1a_offset);
   virtual void fc_get_setup_calib(int& pulse_len, int& l1a_offset);
+  virtual void fc_read_counters(int&  spill_count, int& header_occ, int& header_occ_max, int& event_count, int& vetoed_counter) override;
+
+  virtual void fc_clear_run() override;
+  virtual void fc_advance_l1_fifo() override;
+  virtual void fc_enables_read(bool& ext_l1a, bool& ext_spill, bool& timer_l1a) override;
+  virtual void fc_enables(bool ext_l1a, bool ext_spill, bool timer_l1a) override;
+  virtual void fc_veto_setup_read(bool& veto_daq_busy, bool& veto_l1_occ, int& l1_occ_busy, int& l1_occ_ok) override;
+  virtual void fc_veto_setup(bool veto_daq_busy, bool veto_l1_occ, int l1_occ_busy, int l1_occ_ok) override;
+   
 
   virtual void daq_reset();
   virtual void daq_advance_ptr();

--- a/src/pflib/uhal/uhalWishboneInterface.cxx
+++ b/src/pflib/uhal/uhalWishboneInterface.cxx
@@ -108,6 +108,7 @@ void uhalWishboneInterface::fc_sendL1A() {
   dispatch();
 }
 
+
 void uhalWishboneInterface::fc_linkreset() {
   const ::uhal::Node& m_base(hw_->getNode("LDMX"));
   m_base.getNode("FAST_CONTROL.SEND_LINK_RESET").write(1);
@@ -140,6 +141,144 @@ void uhalWishboneInterface::fc_get_setup_calib(int& pulse_len, int& l1a_offset) 
   dispatch();
   pulse_len=pl;
   l1a_offset=lo;
+}
+
+void uhalWishboneInterface::fc_read_counters(int&  spill_count, int& header_occ, int& header_occ_max, int& event_count, int& vetoed_counter) {
+  const ::uhal::Node& m_base(hw_->getNode("LDMX"));
+  
+  ::uhal::ValWord<uint32_t> occ = m_base.getNode("FAST_CONTROL.OCC").read();
+  ::uhal::ValWord<uint32_t> occ_max = m_base.getNode("FAST_CONTROL.OCC_MAX").read();
+  ::uhal::ValWord<uint32_t> sc = m_base.getNode("FAST_CONTROL.SPILL_COUNT").read();
+  ::uhal::ValWord<uint32_t> ec = m_base.getNode("FAST_CONTROL.EVENT_COUNT").read();
+  ::uhal::ValWord<uint32_t> veto = m_base.getNode("FAST_CONTROL.VETO").read();
+
+  dispatch();
+
+  header_occ=occ;
+  header_occ_max=occ_max;
+  spill_count = sc;
+  event_count = ec;
+  vetoed_counter = veto;
+}
+
+void uhalWishboneInterface::fc_clear_run() {
+  const ::uhal::Node& m_base(hw_->getNode("LDMX"));
+  m_base.getNode("FAST_CONTROL.CLEAR_FIFO").write(0x1);
+  dispatch();
+}
+
+void uhalWishboneInterface::fc_enables_read(bool& ext_l1a, bool& ext_spill, bool& timer_l1a) {
+  const ::uhal::Node& m_base(hw_->getNode("LDMX"));
+
+  ::uhal::ValWord<uint32_t> reg = m_base.getNode("FAST_CONTROL.ENABLES").read();
+  dispatch();
+
+  const int MASK_FC_CONTROL_ENABLE_EXT_L1A = 0x02;
+  const int MASK_FC_CONTROL_ENABLE_EXT_SPILL = 0x01;
+  const int MASK_FC_CONTROL_ENABLE_TIMER_L1A = 0x04;
+  
+  ext_l1a=(reg&MASK_FC_CONTROL_ENABLE_EXT_L1A);
+  ext_spill=(reg&MASK_FC_CONTROL_ENABLE_EXT_SPILL);
+  timer_l1a=(reg&MASK_FC_CONTROL_ENABLE_TIMER_L1A);
+
+}
+
+void uhalWishboneInterface::fc_enables(bool ext_l1a, bool ext_spill, bool timer_l1a) {
+
+  const ::uhal::Node& m_base(hw_->getNode("LDMX"));
+
+  ::uhal::ValWord<uint32_t> regval = m_base.getNode("FAST_CONTROL.ENABLES").read();
+  dispatch();
+
+  uint32_t reg = regval;
+
+  const int MASK_FC_CONTROL_ENABLE_EXT_L1A = 0x02;
+  const int MASK_FC_CONTROL_ENABLE_EXT_SPILL = 0x01;
+  const int MASK_FC_CONTROL_ENABLE_TIMER_L1A = 0x04;
+
+  reg|=MASK_FC_CONTROL_ENABLE_EXT_L1A;
+  if (!ext_l1a) reg^=MASK_FC_CONTROL_ENABLE_EXT_L1A;
+
+  reg|=MASK_FC_CONTROL_ENABLE_EXT_SPILL;
+  if (!ext_spill) reg^=MASK_FC_CONTROL_ENABLE_EXT_SPILL;
+
+  reg|=MASK_FC_CONTROL_ENABLE_TIMER_L1A;
+  if (!timer_l1a) reg^=MASK_FC_CONTROL_ENABLE_TIMER_L1A;
+
+  m_base.getNode("FAST_CONTROL.ENABLES").write(reg);
+  dispatch();
+}
+
+//time setup read
+
+//timer setup
+
+void uhalWishboneInterface::fc_veto_setup_read(bool& veto_daq_busy, bool& veto_l1_occ, int& l1_occ_busy, int& l1_occ_ok) {
+  const ::uhal::Node& m_base(hw_->getNode("LDMX"));
+
+  ::uhal::ValWord<uint32_t> vetoregval = m_base.getNode("FAST_CONTROL.VETO_SETUP").read();
+  dispatch();
+
+  uint32_t vetoreg = vetoregval;
+
+  const int MASK_FC_CONTROL_ENABLE_VETO_BUSY_DAQ  = 0x08;
+  const int MASK_FC_CONTROL_ENABLE_VETO_HEADEROCC = 0x10;
+
+  veto_daq_busy=(vetoreg&MASK_FC_CONTROL_ENABLE_VETO_BUSY_DAQ)!=0;
+  veto_l1_occ=(vetoreg&MASK_FC_CONTROL_ENABLE_VETO_HEADEROCC)!=0;
+
+   ::uhal::ValWord<uint32_t> occregval = m_base.getNode("FAST_CONTROL.OCCVETO").read();
+  dispatch();
+
+  uint32_t occreg = occregval; 
+
+  const int MASK_FC_OCCBUSY = 0xFF;
+  const int SHIFT_FC_OCC_OK = 12;
+  const int SHIFT_FC_OCCBUSY = 0;
+  const int MASK_FC_OCC_OK = 0xFF;
+
+  l1_occ_busy=(occreg>>SHIFT_FC_OCCBUSY)&MASK_FC_OCCBUSY;
+  l1_occ_ok=(occreg>>SHIFT_FC_OCC_OK)&MASK_FC_OCC_OK;
+
+}
+
+//veto setup
+void uhalWishboneInterface::fc_veto_setup(bool veto_daq_busy, bool veto_l1_occ, int l1_occ_busy, int l1_occ_ok) {
+
+  const ::uhal::Node& m_base(hw_->getNode("LDMX"));
+
+  ::uhal::ValWord<uint32_t> regval = m_base.getNode("FAST_CONTROL.VETO_SETUP").read();
+  dispatch();
+
+  uint32_t reg = regval;
+
+  const int MASK_FC_CONTROL_ENABLE_VETO_BUSY_DAQ  = 0x08;
+  const int MASK_FC_CONTROL_ENABLE_VETO_HEADEROCC = 0x10;
+
+  reg|=(MASK_FC_CONTROL_ENABLE_VETO_BUSY_DAQ|MASK_FC_CONTROL_ENABLE_VETO_HEADEROCC);
+  if (!veto_daq_busy) reg^=MASK_FC_CONTROL_ENABLE_VETO_BUSY_DAQ;
+  if (!veto_l1_occ) reg^=MASK_FC_CONTROL_ENABLE_VETO_HEADEROCC;
+   
+  m_base.getNode("FAST_CONTROL.VETO_SETUP").write(reg);
+  dispatch();
+
+  const int MASK_FC_OCCBUSY = 0xFF;
+  const int SHIFT_FC_OCC_OK = 12;
+  const int SHIFT_FC_OCCBUSY = 0;
+  const int MASK_FC_OCC_OK = 0xFF;
+
+  uint32_t occreg=((l1_occ_busy&MASK_FC_OCCBUSY)<<SHIFT_FC_OCCBUSY)|((l1_occ_ok&MASK_FC_OCC_OK)<<SHIFT_FC_OCC_OK);
+
+  m_base.getNode("FAST_CONTROL.OCCVETO").write(occreg);
+  dispatch(); 
+
+}
+
+
+void uhalWishboneInterface::fc_advance_l1_fifo() {
+  const ::uhal::Node& m_base(hw_->getNode("LDMX"));
+  m_base.getNode("FAST_CONTROL.ADVANCE_L1_FIFO").write(1);
+  dispatch();
 }
 
 void uhalWishboneInterface::daq_reset() {

--- a/src/pflib/uhal/uhalWishboneInterface.cxx
+++ b/src/pflib/uhal/uhalWishboneInterface.cxx
@@ -108,7 +108,6 @@ void uhalWishboneInterface::fc_sendL1A() {
   dispatch();
 }
 
-
 void uhalWishboneInterface::fc_linkreset() {
   const ::uhal::Node& m_base(hw_->getNode("LDMX"));
   m_base.getNode("FAST_CONTROL.SEND_LINK_RESET").write(1);
@@ -209,10 +208,6 @@ void uhalWishboneInterface::fc_enables(bool ext_l1a, bool ext_spill, bool timer_
   dispatch();
 }
 
-//time setup read
-
-//timer setup
-
 void uhalWishboneInterface::fc_veto_setup_read(bool& veto_daq_busy, bool& veto_l1_occ, int& l1_occ_busy, int& l1_occ_ok) {
   const ::uhal::Node& m_base(hw_->getNode("LDMX"));
 
@@ -227,7 +222,7 @@ void uhalWishboneInterface::fc_veto_setup_read(bool& veto_daq_busy, bool& veto_l
   veto_daq_busy=(vetoreg&MASK_FC_CONTROL_ENABLE_VETO_BUSY_DAQ)!=0;
   veto_l1_occ=(vetoreg&MASK_FC_CONTROL_ENABLE_VETO_HEADEROCC)!=0;
 
-   ::uhal::ValWord<uint32_t> occregval = m_base.getNode("FAST_CONTROL.OCCVETO").read();
+   ::uhal::ValWord<uint32_t> occregval = m_base.getNode("FAST_CONTROL.OCC_VETO").read();
   dispatch();
 
   uint32_t occreg = occregval; 
@@ -242,7 +237,6 @@ void uhalWishboneInterface::fc_veto_setup_read(bool& veto_daq_busy, bool& veto_l
 
 }
 
-//veto setup
 void uhalWishboneInterface::fc_veto_setup(bool veto_daq_busy, bool veto_l1_occ, int l1_occ_busy, int l1_occ_ok) {
 
   const ::uhal::Node& m_base(hw_->getNode("LDMX"));
@@ -269,7 +263,7 @@ void uhalWishboneInterface::fc_veto_setup(bool veto_daq_busy, bool veto_l1_occ, 
 
   uint32_t occreg=((l1_occ_busy&MASK_FC_OCCBUSY)<<SHIFT_FC_OCCBUSY)|((l1_occ_ok&MASK_FC_OCC_OK)<<SHIFT_FC_OCC_OK);
 
-  m_base.getNode("FAST_CONTROL.OCCVETO").write(occreg);
+  m_base.getNode("FAST_CONTROL.OCC_VETO").write(occreg);
   dispatch(); 
 
 }

--- a/uhal/uMNio-ldmx.xml
+++ b/uhal/uMNio-ldmx.xml
@@ -30,6 +30,16 @@
      <node id="STATIC_BITS" address="0" permission="rw" mask="0xF00"/>
      <node id="CALIB_PULSE_LEN" address="2" permission="rw"  mask="0x0F000000"/>
      <node id="CALIB_L1A_OFFSET" address="2" permission="rw" mask="0x00FF0000"/>
+     <node id="OCC" address="0x44" permission="r" mask="0xFF"/>
+     <node id="OCC_MAX" address="0x44" permission="r" mask="0xFF00" />
+     <node id="SPILL_COUNT" address="0x44" permission="r" mask="0xFFF0000"/>
+     <node id="EVENT_COUNT" address="0x45" permission="r" />
+     <node id="VETO" address="0x49" permission="r" mask="0xFFF" />
+     <node id="CLEAR_FIFO" address="0x1" permission="rw" mask="0x10" />
+     <node id="ADVANCE_L1_FIFO" address="0x1" permission="rw" mask="0x20" />
+     <node id="ENABLES" address="0x0" permission="rw" />
+     <node id="VETO_SETUP" address="0x0" permission="rw" />
+     <node id="OCCVETO" address="4" permission="rw" />
   </node>
   <node id="WISHBONE" address="0x100000">
     <node id="WB_WRITE_DATA" address="0x3" description="Data to write"/>

--- a/uhal/uMNio-ldmx.xml
+++ b/uhal/uMNio-ldmx.xml
@@ -39,7 +39,7 @@
      <node id="ADVANCE_L1_FIFO" address="0x1" permission="rw" mask="0x20" />
      <node id="ENABLES" address="0x0" permission="rw" />
      <node id="VETO_SETUP" address="0x0" permission="rw" />
-     <node id="OCCVETO" address="4" permission="rw" />
+     <node id="OCC_VETO" address="4" permission="rw" />
   </node>
   <node id="WISHBONE" address="0x100000">
     <node id="WB_WRITE_DATA" address="0x3" description="Data to write"/>


### PR DESCRIPTION
Copied over some developments done on the Rogue Wishbone interface during the testbeam to uHAL, as we are using that on the setup in Lund instead of Rogue.

We won't be using external triggers, vetos etc. in Lund, so now they can be properly disabled. 