### PR TITLE
Iss79 bias for active boards

### DIFF
--- a/tool/pftool_bias.cc
+++ b/tool/pftool_bias.cc
@@ -38,7 +38,7 @@ void set_bias_on_all_active_boards(PolarfireTarget* pft,
     }
   }
 }
-void set_bias_on_all_connectors(PolarfireTarget* pft,
+void set_bias_on_all_boards(PolarfireTarget* pft,
                                 const int num_boards,
                                 const bool set_led,
                                 const int dac_value) {
@@ -51,7 +51,7 @@ void set_bias_on_all_connectors(PolarfireTarget* pft,
     }
 }
 
-void set_bias_on_all_connectors(PolarfireTarget* pft) {
+void set_bias_on_all_boards(PolarfireTarget* pft) {
     static int dac_value {0};
     static int led_or_sipm {0};
     const int num_boards {get_num_rocs()};
@@ -62,7 +62,7 @@ void set_bias_on_all_connectors(PolarfireTarget* pft) {
         return;
     }
     bool set_led {led_or_sipm == 1};
-    set_bias_on_all_connectors(pft, num_boards, set_led, dac_value);
+    set_bias_on_all_boards(pft, num_boards, set_led, dac_value);
 }
 
 void bias( const std::string& cmd, PolarfireTarget* pft )
@@ -78,7 +78,7 @@ void bias( const std::string& cmd, PolarfireTarget* pft )
     initialize_bias(pft, iboard);
   }
   if (cmd=="SET_ALL") {
-      set_bias_on_all_connectors(pft);
+      set_bias_on_all_boards(pft);
   }
   if (cmd=="SET") {
     iboard=BaseMenu::readline_int("Which board? ",iboard);

--- a/tool/pftool_bias.cc
+++ b/tool/pftool_bias.cc
@@ -16,7 +16,20 @@ void initialize_bias(PolarfireTarget* pft,
     pflib::Bias bias=pft->hcal.bias(iboard);
     bias.initialize();
 }
-
+void set_bias_on_all_active_boards(PolarfireTarget* pft,
+                                   const bool set_led,
+                                   const int dac_value)
+{
+  std::vector<int> active_boards{get_rocs_with_active_links(pft)};
+  for (const auto board : active_boards) {
+    const int num_connections = 16;
+    const int led_bias{0};
+    initialize_bias(pft, board);
+    for (int connection{0}; connection < num_connections; ++connection) {
+      pft->setBiasSetting(board, set_led, connection, dac_value);
+    }
+  }
+}
 void set_bias_on_all_connectors(PolarfireTarget* pft,
                                 const int num_boards,
                                 const bool set_led,

--- a/tool/pftool_bias.cc
+++ b/tool/pftool_bias.cc
@@ -16,14 +16,22 @@ void initialize_bias(PolarfireTarget* pft,
     pflib::Bias bias=pft->hcal.bias(iboard);
     bias.initialize();
 }
+void set_bias_on_all_active_boards(PolarfireTarget* pft)
+{
+  static int led_sipm {0};
+  led_sipm=BaseMenu::readline_int(" SiPM(0) or LED(1)? ", led_sipm);
+  static int dac {0};
+  dac=BaseMenu::readline_int(" What DAC value? ", dac);
+  set_bias_on_all_active_boards(pft, led_sipm == 1, dac);
+}
 void set_bias_on_all_active_boards(PolarfireTarget* pft,
                                    const bool set_led,
                                    const int dac_value)
 {
   std::vector<int> active_boards{get_rocs_with_active_links(pft)};
   for (const auto board : active_boards) {
-    const int num_connections = 16;
     const int led_bias{0};
+    const int num_connections {16};
     initialize_bias(pft, board);
     for (int connection{0}; connection < num_connections; ++connection) {
       pft->setBiasSetting(board, set_led, connection, dac_value);

--- a/tool/pftool_bias.cc
+++ b/tool/pftool_bias.cc
@@ -9,7 +9,7 @@ void initialize_bias_on_all_boards(PolarfireTarget* pft, const int num_boards) {
       initialize_bias(pft, board);
     }
 }
-void set_bias_on_all_connectors(PolarfireTarget* pft, const int board,
+void set_bias_on_each_connector(PolarfireTarget* pft, const int board,
                                 const bool set_led,
                                 const int dac_value) {
   const int num_connections {16};
@@ -40,7 +40,7 @@ void set_bias_on_all_active_boards(PolarfireTarget* pft,
   for (const auto board : active_boards) {
     const int led_bias{0};
     initialize_bias(pft, board);
-    set_bias_on_all_connectors(pft, board, set_led, dac_value);
+    set_bias_on_each_connector(pft, board, set_led, dac_value);
   }
 }
 void set_bias_on_all_boards(PolarfireTarget* pft,
@@ -99,7 +99,7 @@ void bias( const std::string& cmd, PolarfireTarget* pft )
     }
     if (ichan==-1) {
       printf("\n Setting bias on all 16 connectors. \n");
-      set_bias_on_all_connectors(pft, iboard, led_sipm==1,dac);
+      set_bias_on_each_connector(pft, iboard, led_sipm==1,dac);
     }
   }
   if (cmd=="LOAD") {

--- a/tool/pftool_bias.cc
+++ b/tool/pftool_bias.cc
@@ -9,6 +9,14 @@ void initialize_bias_on_all_boards(PolarfireTarget* pft, const int num_boards) {
       initialize_bias(pft, board);
     }
 }
+void set_bias_on_all_connectors(PolarfireTarget* pft, const int board,
+                                const bool set_led,
+                                const int dac_value) {
+  const int num_connections {16};
+  for (int connection{0}; connection < num_connections; ++connection) {
+    pft->setBiasSetting(board, set_led, connection, dac_value);
+  }
+}
 void initialize_bias(PolarfireTarget* pft,
                      const int iboard)
 {
@@ -31,11 +39,8 @@ void set_bias_on_all_active_boards(PolarfireTarget* pft,
   std::vector<int> active_boards{get_rocs_with_active_links(pft)};
   for (const auto board : active_boards) {
     const int led_bias{0};
-    const int num_connections {16};
     initialize_bias(pft, board);
-    for (int connection{0}; connection < num_connections; ++connection) {
-      pft->setBiasSetting(board, set_led, connection, dac_value);
-    }
+    set_bias_on_all_connectors(pft, board, set_led, dac_value);
   }
 }
 void set_bias_on_all_boards(PolarfireTarget* pft,
@@ -91,9 +96,7 @@ void bias( const std::string& cmd, PolarfireTarget* pft )
     }
     if (ichan==-1) {
       printf("\n Setting bias on all 16 connectors. \n");
-      for(int k = 0; k < 16; k++){
-        pft->setBiasSetting(iboard,led_sipm==1,k,dac);
-      }
+      set_bias_on_all_connectors(pft, iboard, led_sipm==1,dac);
     }
   }
   if (cmd=="LOAD") {

--- a/tool/pftool_bias.cc
+++ b/tool/pftool_bias.cc
@@ -85,6 +85,9 @@ void bias( const std::string& cmd, PolarfireTarget* pft )
   if (cmd=="SET_ALL") {
       set_bias_on_all_boards(pft);
   }
+  if (cmd=="SET_ACTIVE") {
+    set_bias_on_all_active_boards(pft);
+  }
   if (cmd=="SET") {
     iboard=BaseMenu::readline_int("Which board? ",iboard);
     static int led_sipm=0;
@@ -114,7 +117,8 @@ auto menu_bias = pftool::menu("BIAS","bias voltage settings")
   //->line("STATUS","Read the bias line settings", bias )
   ->line("INIT","Initialize a board", bias )
   ->line("SET","Set a specific bias line setting", bias )
-  ->line("SET_ALL", "Set a specific bias line setting to every connector", bias)
+  ->line("SET_ALL", "Set a specific bias line setting to every connector on each board", bias)
+  ->line("SET_ACTIVE", "Set a speficic bias line setting to every connector on each board that has active links", bias)
   ->line("LOAD","Load bias values from file", bias )
 ;
 }

--- a/tool/pftool_bias.h
+++ b/tool/pftool_bias.h
@@ -21,6 +21,9 @@
  */
 void bias( const std::string& cmd, pflib::PolarfireTarget* pft );
 
+void set_bias_on_all_active_boards(pflib::PolarfireTarget* pft,
+                                   const bool set_led,
+                                   const int dac_value);
 void set_bias_on_all_connectors(pflib::PolarfireTarget* pft,
                                 const int num_boards,
                                 const bool set_led,

--- a/tool/pftool_bias.h
+++ b/tool/pftool_bias.h
@@ -25,11 +25,11 @@ void set_bias_on_all_active_boards(pflib::PolarfireTarget* pft);
 void set_bias_on_all_active_boards(pflib::PolarfireTarget* pft,
                                    const bool set_led,
                                    const int dac_value);
-void set_bias_on_all_connectors(pflib::PolarfireTarget* pft,
-                                const int num_boards,
-                                const bool set_led,
-                                const int dac_value);
-void set_bias_on_all_connectors(pflib::PolarfireTarget* pft);
+void set_bias_on_all_boards(pflib::PolarfireTarget* pft,
+                            const int num_boards,
+                            const bool set_led,
+                            const int dac_value);
+void set_bias_on_all_boards(pflib::PolarfireTarget* pft);
 
 void initialize_bias_on_all_boards(pflib::PolarfireTarget* pft,
                                    const int num_boards = 3);

--- a/tool/pftool_bias.h
+++ b/tool/pftool_bias.h
@@ -21,6 +21,7 @@
  */
 void bias( const std::string& cmd, pflib::PolarfireTarget* pft );
 
+void set_bias_on_all_active_boards(pflib::PolarfireTarget* pft);
 void set_bias_on_all_active_boards(pflib::PolarfireTarget* pft,
                                    const bool set_led,
                                    const int dac_value);

--- a/tool/pftool_bias.h
+++ b/tool/pftool_bias.h
@@ -21,6 +21,10 @@
  */
 void bias( const std::string& cmd, pflib::PolarfireTarget* pft );
 
+void set_bias_on_all_connectors(pflib::PolarfireTarget* pft,
+                                const int board,
+                                const bool set_led,
+                                const int dac_value);
 void set_bias_on_all_active_boards(pflib::PolarfireTarget* pft);
 void set_bias_on_all_active_boards(pflib::PolarfireTarget* pft,
                                    const bool set_led,

--- a/tool/pftool_roc.cc
+++ b/tool/pftool_roc.cc
@@ -1,4 +1,16 @@
 #include "pftool_roc.h"
+std::vector<int> get_rocs_with_active_links(PolarfireTarget* pft) {
+
+  std::vector<int> active_boards{};
+  const int num_boards {get_num_rocs()};
+  const pflib::Elinks& elinks {pft->hcal.elinks()};
+  for (int board {0}; board < num_boards; ++board) {
+    if (elinks.isActive(2 * board)|| elinks.isActive(2 *board + 1)) {
+      active_boards.push_back(board);
+    }
+  }
+  return active_boards;
+}
 int iroc = 0;
 void roc_render( PolarfireTarget* pft ) {
   printf(" Active ROC: %d\n",iroc);

--- a/tool/pftool_roc.h
+++ b/tool/pftool_roc.h
@@ -68,6 +68,7 @@ void load_parameters(PolarfireTarget* pft, const int config_version,
  */
 void roc( const std::string& cmd, PolarfireTarget* pft );
 
+std::vector<int> get_rocs_with_active_links(pflib::PolarfireTarget* pft);
 int get_num_rocs();
 int get_dpm_number(pflib::PolarfireTarget* pft = nullptr);
 int get_num_channels_per_elink();

--- a/tool/pftool_tasks.cc
+++ b/tool/pftool_tasks.cc
@@ -202,7 +202,7 @@ void preamp_alignment(PolarfireTarget* pft)
   if (BaseMenu::readline_bool("Update SiPM bias?", false)) {
     const int num_boards {get_num_rocs()};
     const int SiPM_bias {3784};
-    set_bias_on_all_connectors(pft, num_boards, false, SiPM_bias);
+    set_bias_on_all_boards(pft, num_boards, false, SiPM_bias);
   }
 
   //Choose goal for pedestal
@@ -866,7 +866,7 @@ void tasks( const std::string& cmd, pflib::PolarfireTarget* pft )
     prepare_charge_injection(pft);
     const int SiPM_bias = BaseMenu::readline_int("SiPM bias: ", 0);
     const int num_boards{get_num_rocs()};
-    set_bias_on_all_connectors(pft, num_boards, false, SiPM_bias);
+    set_bias_on_all_boards(pft, num_boards, false, SiPM_bias);
 
 
     scan_N_steps(pft,
@@ -917,7 +917,7 @@ void beamprep(pflib::PolarfireTarget *pft) {
 
   static int SiPM_bias{3784};
   SiPM_bias = BaseMenu::readline_int("SiPM Bias", SiPM_bias);
-  set_bias_on_all_connectors(pft, num_boards, false, SiPM_bias);
+  set_bias_on_all_boards(pft, num_boards, false, SiPM_bias);
   if (!BaseMenu::readline_bool("Skip customizing? (Recommended)", true)) {
 
     static int gain_conv{4};
@@ -929,7 +929,7 @@ void beamprep(pflib::PolarfireTarget *pft) {
     poke_all_rochalves(pft, "Digital_Half_", "L1OFFSET", l1offset);
   }
   if (BaseMenu::readline_bool("Disable LED bias? (Recommended)", true)) {
-    set_bias_on_all_connectors(pft, num_boards, true, 0);
+    set_bias_on_all_boards(pft, num_boards, true, 0);
   }
   std::cout << "Fastcontrol settings\n";
   // BUSY, OCC, Dont ask the user
@@ -1021,7 +1021,7 @@ void calibrun_ledruns(pflib::PolarfireTarget* pft,
   fc_calib(pft, hc.led_calib_length, hc.led_calib_offset);
   const int num_boards{get_num_rocs()};
   std::cout << "Setting SiPM bias to " << hc.SiPM_bias << " on all boards in case it was disabled for the charge injection runs"  << std::endl;
-  set_bias_on_all_connectors(pft, num_boards, false, hc.SiPM_bias);
+  set_bias_on_all_boards(pft, num_boards, false, hc.SiPM_bias);
 
 
     // IntCtest should be off
@@ -1039,7 +1039,7 @@ void calibrun_ledruns(pflib::PolarfireTarget* pft,
     for (int i {0}; i < hc.led_dac_values.size(); ++i) {
       const int dac_value {hc.led_dac_values[i]};
       std::cout << "Doing LED run with dac value: " << dac_value << std::endl;
-      set_bias_on_all_connectors(pft, num_rocs, true, dac_value);
+      set_bias_on_all_boards(pft, num_rocs, true, dac_value);
 
       pft->prepareNewRun();
       daq_run(pft, led_command, run, hc.num_led_events, rate, led_filenames[i]);
@@ -1080,10 +1080,10 @@ void calibrun(pflib::PolarfireTarget* pft,
   const int num_boards {get_num_rocs()};
   const int LED_bias {0};
   std::cout << "Disabling LED bias" << std::endl;
-  set_bias_on_all_connectors(pft, num_boards, true, LED_bias);
+  set_bias_on_all_boards(pft, num_boards, true, LED_bias);
 
   std::cout << "Setting SiPM bias to " << hc.SiPM_bias << " on all boards" << std::endl;
-  set_bias_on_all_connectors(pft, num_boards, false, hc.SiPM_bias);
+  set_bias_on_all_boards(pft, num_boards, false, hc.SiPM_bias);
 
   std::cout << "... Done" << std::endl;
 
@@ -1112,10 +1112,10 @@ void calibrun(pflib::PolarfireTarget* pft,
 
   const std::vector<int> SiPM_biases {hc.SiPM_bias};
 
-  for (auto SiPM_bias : SiPM_biases) {
+  for (auto SiPM_bias : SiPM_biases) { //
     std::cout << "Running charge injection for SiPM bias: " << SiPM_bias << std::endl;
     std::cout << "Setting SiPM bias to " << SiPM_bias << " on all boards" << std::endl;
-    set_bias_on_all_connectors(pft, num_boards, false, SiPM_bias);
+    set_bias_on_all_boards(pft, num_boards, false, SiPM_bias);
 
     std::cout << "Running charge injection with lowrange from "  <<
       hc.lowrange_dac_min << " to " << hc.lowrange_dac_max << std::endl;


### PR DESCRIPTION
This fixes iss79 and does a small refactoring to the pftool_bias TU, renaming the `set_bias_on_all_connectors` function to `set_bias_on_all_boards` which is a more accurate description of what it actually does. Then goes ahead and factors out the code that actually does set the bias on each connector of a board into a function with a similar (but not the same) name. 