### PR TITLE
add multiple tries when reading bytes over I2C

### DIFF
--- a/include/pflib/I2C.h
+++ b/include/pflib/I2C.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "pflib/Exception.h"
+#include "pflib/Logging.h"
 
 namespace pflib {
 
@@ -16,6 +17,7 @@ namespace pflib {
  */
 class I2C {
  protected:
+  mutable logging::logger the_log_{logging::get("I2C")};
   I2C() {}
 
  public:

--- a/include/pflib/I2C_Linux.h
+++ b/include/pflib/I2C_Linux.h
@@ -51,6 +51,8 @@ class I2C_Linux : public I2C {
                                           int nread = 0);
 
  private:
+  void obtain_control(uint8_t i2c_dev_addr);
+ private:
   int handle_;
   std::string dev_;
 };

--- a/src/pflib/I2C_Linux.cxx
+++ b/src/pflib/I2C_Linux.cxx
@@ -16,8 +16,9 @@ I2C_Linux::I2C_Linux(const std::string& device) {
   dev_ = device;
   handle_ = open(device.c_str(), O_RDWR);
   if (handle_ < 0) {
-    std::string msg = "Unable to open " + device;
-    PFEXCEPTION_RAISE("DeviceFileAccessError", msg);
+    std::stringstream msg{"Unable to open "};
+    msg << device << " with errno " << errno;
+    PFEXCEPTION_RAISE("DeviceFileAccessError", msg.str());
   }
   pflib_log(debug) << "opening " << dev_ << " at " << handle_;
 }
@@ -35,16 +36,43 @@ int I2C_Linux::get_bus_speed() {
   return 100;  // only as set in the firmware...
 }
 
+void I2C_Linux::obtain_control(uint8_t i2c_dev_addr) {
+  int ret = ioctl(handle_, 0x0703, i2c_dev_addr);
+  pflib_log(trace) << "ioctl(" << hex(handle_) << ", 0x0703, " << hex(i2c_dev_addr) << ") -> " << ret;
+  if (ret < 0) {
+    std::stringstream msg{"Unable to obtain control of "};
+    msg << hex(i2c_dev_addr) << " on " << dev_ << " errno " << errno;
+    switch (errno) {
+      case EBADF:
+        msg << " (EBADF) " << hex(handle_) << " is not a valid file descriptor";
+        break;
+      case EFAULT:
+        msg << " (EFAULT) arguments reference inaccessible memory";
+        break;
+      case EINVAL:
+        msg << " (EINVAL) invalid inputs: 0x0703 or " << hex(i2c_dev_addr);
+        break;
+      case ENOTTY:
+        msg << " (ENOTTY) operation does not apply to the type " << dev_ << " references";
+        break;
+      default:
+        msg << " unknown error number";
+        break;
+    }
+    PFEXCEPTION_RAISE("IOCtrl", msg.str());
+  }
+}
+
 static int n_tries = 4;
 
 void I2C_Linux::write_byte(uint8_t i2c_dev_addr, uint8_t data) {
-  ioctl(handle_, 0x0703, i2c_dev_addr);
+  obtain_control(i2c_dev_addr);
 
   int rv{-1};
   for (std::size_t i_try{0}; i_try < n_tries; i_try++) {
     rv = write(handle_, &data, 1);
     if (rv >= 0) {
-      pflib_log(trace) << "wrote " << hex(data);
+      pflib_log(trace) << "wrote " << hex(data) << " to " << hex(i2c_dev_addr);
       // success! let's leave
       return;
     }
@@ -57,22 +85,44 @@ void I2C_Linux::write_byte(uint8_t i2c_dev_addr, uint8_t data) {
 }
 
 uint8_t I2C_Linux::read_byte(uint8_t i2c_dev_addr) {
-  ioctl(handle_, 0x0703, i2c_dev_addr);
+  obtain_control(i2c_dev_addr);
   uint8_t buffer[8];
-
   int rv{-1};
   for (std::size_t i_try{0}; i_try < n_tries; i_try++) {
     rv = read(handle_, buffer, 1);
+    pflib_log(trace) << "read(" << hex(handle_) << ", " << hex(buffer) << ", 1) -> " << rv << " errno " << errno;
     if (rv >= 0) {
-      pflib_log(trace) << "read " << hex(buffer[0]);
+      pflib_log(trace) << "read " << hex(buffer[0]) << " from " << hex(i2c_dev_addr);
       // success! let's leave
       return buffer[0];
     }
   }
-  char message[120];
-  snprintf(message, 120, "Error %d reading from i2c target 0x%02x", errno,
-           i2c_dev_addr);
-  PFEXCEPTION_RAISE("I2CError", message);
+  std::stringstream msg;
+  msg << errno;
+  switch (errno) {
+    case EAGAIN:
+      msg << " (EAGAIN) " << dev_ << "(" << hex(handle_) << ") is marked as non blocking";
+      break;
+    case EBADF:
+      msg << " (EBADF) " << dev_ << "(" << hex(handle_) << ") is not a valid descriptor or not open for reading";
+      break;
+    case EFAULT:
+      msg << " (EFAULT) buffer is outside accessible address space";
+      break;
+    case EINTR:
+      msg << " (EINTR) signal interrupted call";
+      break;
+    case EINVAL:
+      msg << " (EINVAL) buffer address or file offset is not aligned";
+      break;
+    case EIO:
+      msg << " (EIO) generic I/O error";
+      break;
+    case EISDIR:
+      msg << " (EISDIR) " << dev_ << "(" << hex(handle_) << ") refers to a directory";
+      break;
+  }
+  PFEXCEPTION_RAISE("I2CError", msg.str());
   return buffer[0];
 }
 

--- a/src/pflib/ROC.cxx
+++ b/src/pflib/ROC.cxx
@@ -14,7 +14,9 @@ namespace pflib {
 ROC::ROC(I2C& i2c, uint8_t roc_base_addr, const std::string& type_version)
     : i2c_{i2c},
       roc_base_{roc_base_addr},
-      compiler_{Compiler::get(type_version)} {}
+      compiler_{Compiler::get(type_version)} {
+  pflib_log(debug) << "base addr " << packing::hex(roc_base_);
+}
 
 std::vector<uint8_t> ROC::readPage(int ipage, int len) {
   i2c_.set_bus_speed(1400);
@@ -36,6 +38,8 @@ uint8_t ROC::getValue(int ipage, int offset) {
 
   // set the address
   uint16_t fulladdr = (ipage << 5) | offset;
+  pflib_log(debug) << "ROC::getValue(" << ipage << ", " << offset
+                   << ") -> full addr " << fulladdr;
   i2c_.write_byte(roc_base_ + 0, fulladdr & 0xFF);
   i2c_.write_byte(roc_base_ + 1, (fulladdr >> 8) & 0xFF);
   // now read


### PR DESCRIPTION
In the HGCROCV3b, there is an imperfection in the I2C block which may occasionally result in I2C errors -- there is also the issue of things just locking up, which is what the fw-loader reload addresses.

## To Do
- [ ] make sure this functions