### PR TITLE
initialize an optional containerized development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ install**
 *~
 docs/html/**
 tool/test-menu
+
+.denv
+.bash*

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,9 @@ build**
 install**
 *.raw
 *.root
-.*.swp
 *~
 docs/html/**
 tool/test-menu
 
-.denv
-.bash*
+# ignore all hidden files
+.*

--- a/env/Containerfile
+++ b/env/Containerfile
@@ -1,0 +1,23 @@
+FROM almalinux:9.4
+LABEL maintainer="Tom Eichlersmith <eichl008@umn.edu>"
+LABEL os.version="almalinux:9.4"
+RUN yum -y install \
+  gcc \
+  g++ \
+  cmake \
+  readline-devel \
+  boost-devel \
+  wget \
+  python3 \
+  python-yaml \
+  git
+RUN mkdir src &&\
+    wget -q -O- https://github.com/jbeder/yaml-cpp/archive/refs/tags/0.8.0.tar.gz |\
+      tar -xz --strip-components=1 --directory src &&\
+    cmake \
+      -S src/ \
+      -B src/build \
+      -DYAML_BUILD_SHARED_LIBS=ON \
+    &&\
+    cmake --build src/build --target install &&\
+    rm -rf src

--- a/env/README.md
+++ b/env/README.md
@@ -1,0 +1,22 @@
+# pflib Development Environment
+If you're like me and you want your development environment to be
+identical to the production environment (the ZCU in this case),
+I've written this `Containerfile` that can build an image replicating
+the ZCU _software_ environment.
+
+The image will be missing the _firmware_ environment necessary to do
+all of the communication tasks, but it can still be helpful to develop
+on a friendlier system with more cores.
+
+### Build Image
+```
+# what I did
+podman image build env/ -t pflib-env:latest
+# I think this can work
+docker build env/ -f env/Containerfile -t pflib-env:latest
+```
+
+### Initialize
+```
+denv init pflib-env:latest
+```


### PR DESCRIPTION
This containerized environment is only helpful if you find yourself, like me, wanting to develop large components of pflib that **do not require** direct communication with the HGCROC.

Maybe it can be used in the future to do some automatic testing or standard building of the ZCU image. Maybe we will forget about it once all the big development is done and we fall back to a workflow where we are just making small changes while interacting with the HGCROC.