### PR TITLE
patch bug in wait-time calculation in `daq_run`

### DIFF
--- a/app/tool/pftool.cc
+++ b/app/tool/pftool.cc
@@ -797,13 +797,15 @@ static void daq_run(Target* pft, const std::string& cmd, int run, int nevents,
   timeval tv0, tvi;
   gettimeofday(&tv0, 0);
   for (int ievt = 0; ievt < nevents; ievt++) {
-    pflib_log(trace) << "daq event occupancy pre-L1A: " << pft->hcal().daq().getEventOccupancy();
+    pflib_log(trace) << "daq event occupancy pre-L1A    : "
+                     << pft->hcal().daq().getEventOccupancy();
     // normally, some other controller would send the L1A
     //  we are sending it so we get data during no signal
     if (cmd == "PEDESTAL") pft->fc().sendL1A();
     if (cmd == "CHARGE") pft->fc().chargepulse();
 
-    pflib_log(trace) << "daq event occupancy post-L1A: " << pft->hcal().daq().getEventOccupancy();
+    pflib_log(trace) << "daq event occupancy post-L1A   : "
+                     << pft->hcal().daq().getEventOccupancy();
     gettimeofday(&tvi, 0);
     double runsec =
         (tvi.tv_sec - tv0.tv_sec) + (tvi.tv_usec - tvi.tv_usec) / 1e6;
@@ -816,8 +818,11 @@ static void daq_run(Target* pft, const std::string& cmd, int run, int nevents,
       //        printf("Sleeping %d\n",usec_ahead);
     }
 
+    pflib_log(trace) << "daq event occupancy after pause: "
+                     << pft->hcal().daq().getEventOccupancy();
+
     std::vector<uint32_t> event = pft->read_event();
-    pflib_log(trace) << "daq event occupancy after read_event: "
+    pflib_log(trace) << "daq event occupancy after read : "
                      << pft->hcal().daq().getEventOccupancy();
     pflib_log(debug) << "event " << ievt << " has " << event.size()
                      << " 32-bit words";

--- a/app/tool/pftool.cc
+++ b/app/tool/pftool.cc
@@ -808,14 +808,13 @@ static void daq_run(Target* pft, const std::string& cmd, int run, int nevents,
                      << pft->hcal().daq().getEventOccupancy();
     gettimeofday(&tvi, 0);
     double runsec =
-        (tvi.tv_sec - tv0.tv_sec) + (tvi.tv_usec - tvi.tv_usec) / 1e6;
-    //      double ratenow=(ievt+1)/runsec;
-    double targettime = (ievt + 1.0) / rate;  // what I'd like the rate to be
+        (tvi.tv_sec - tv0.tv_sec) + (tvi.tv_usec - tv0.tv_usec) / 1e6;
+    double targettime = (ievt + 1.0) / rate;
     int usec_ahead = int((targettime - runsec) * 1e6);
-    // printf("Sleeping %f %f %d\n",runsec,targettime,usec_ahead);
-    if (usec_ahead > 100) {  // if we are running fast...
+    pflib_log(trace) << " at " << runsec << "s instead of " << targettime
+                     << "s aheady by " << usec_ahead << "us";
+    if (usec_ahead > 100) {
       usleep(usec_ahead);
-      //        printf("Sleeping %d\n",usec_ahead);
     }
 
     pflib_log(trace) << "daq event occupancy after pause: "

--- a/app/tool/pftool.cc
+++ b/app/tool/pftool.cc
@@ -817,10 +817,16 @@ static void daq_run(Target* pft, const std::string& cmd, int run, int nevents,
     }
 
     std::vector<uint32_t> event = pft->read_event();
-    pflib_log(trace) << "daq event occupancy after read_event: " << pft->hcal().daq().getEventOccupancy();
+    pflib_log(trace) << "daq event occupancy after read_event: "
+                     << pft->hcal().daq().getEventOccupancy();
     pflib_log(debug) << "event " << ievt << " has " << event.size()
                      << " 32-bit words";
-    Action(event);
+    if (event.size() == 0) {
+      pflib_log(warn) << "event " << ievt
+                      << " did not have any words, skipping.";
+    } else {
+      Action(event);
+    }
   }
 };
 


### PR DESCRIPTION
After a bit more debugging (leading to a few more additions to the logging messages), I found a bug in how the wait time was being calculated. This bug causes us to run too fast and presumably overwhelm the chip. Fixing the bug slows down our L1A/readout requests and thus leads to no events being dropped as documented in #111 .

I am not closing that issue because I am still observing differences between the daq link frame header and common mode word documented in the datasheet and the ones observed here.