### PR TITLE
downgrade decoding messages from warn to trace

### DIFF
--- a/app/pfdecoder.cxx
+++ b/app/pfdecoder.cxx
@@ -152,10 +152,10 @@ int main(int argc, char* argv[]) {
       }
     }
     ep.to_csv(o);
-    if (nevents > 0 and count > nevents) {
+    count++;
+    if (nevents > 0 and count >= nevents) {
       break;
     }
-    count++;
   }
 
   return 0;

--- a/app/pfdecoder.cxx
+++ b/app/pfdecoder.cxx
@@ -128,34 +128,39 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  o << std::boolalpha;
-  o << "link,bx,event,orbit,channel,Tp,Tc,adc_tm1,adc,tot,toa\n";
-
-  pflib::packing::SingleROCEventPacket ep;
-  // count is NOT written into output file,
-  // we use the event number from the links
-  // this is just to allow users to limit the number of entries in
-  // the output CSV if desired
-  int count{0};
-
-  while (r) {
-    pflib_log(info) << "popping " << count << " event from stream";
-    r >> ep;
-    pflib_log(debug) << "r.eof(): " << std::boolalpha << r.eof()
-                     << " and bool(r): " << bool(r);
-    if (headers) {
-      for (std::size_t i_link{0}; i_link < 2; i_link++) {
-        const auto& daq_link{ep.daq_links[i_link]};
-        std::cout << "Link " << i_link << " : " << "BX = " << daq_link.bx
-                  << " Event = " << daq_link.event
-                  << " Orbit = " << daq_link.orbit << std::endl;
+  try {
+    o << std::boolalpha;
+    o << "link,bx,event,orbit,channel,Tp,Tc,adc_tm1,adc,tot,toa\n";
+  
+    pflib::packing::SingleROCEventPacket ep;
+    // count is NOT written into output file,
+    // we use the event number from the links
+    // this is just to allow users to limit the number of entries in
+    // the output CSV if desired
+    int count{0};
+  
+    while (r) {
+      pflib_log(info) << "popping " << count << " event from stream";
+      r >> ep;
+      pflib_log(debug) << "r.eof(): " << std::boolalpha << r.eof()
+                       << " and bool(r): " << bool(r);
+      if (headers) {
+        for (std::size_t i_link{0}; i_link < 2; i_link++) {
+          const auto& daq_link{ep.daq_links[i_link]};
+          std::cout << "Link " << i_link << " : " << "BX = " << daq_link.bx
+                    << " Event = " << daq_link.event
+                    << " Orbit = " << daq_link.orbit << std::endl;
+        }
+      }
+      ep.to_csv(o);
+      count++;
+      if (nevents > 0 and count >= nevents) {
+        break;
       }
     }
-    ep.to_csv(o);
-    count++;
-    if (nevents > 0 and count >= nevents) {
-      break;
-    }
+  } catch (const std::runtime_error& e) {
+    pflib_log(fatal) << e.what();
+    return 1;
   }
 
   return 0;

--- a/include/pflib/packing/DAQLinkFrame.h
+++ b/include/pflib/packing/DAQLinkFrame.h
@@ -27,12 +27,6 @@ class DAQLinkFrame {
   int event;
   /// orbit id number
   int orbit;
-  /// error present in one of the counters
-  bool counter_err;
-  /// error present in first quarter (ch0-17 and cm)
-  bool first_quarter_err;
-  /// error present in second quarter (calib and ch18-35)
-  bool second_quarter_err;
   /// flag if this is the first event
   bool first_event;
   /// adc readout from common mode 0
@@ -40,8 +34,23 @@ class DAQLinkFrame {
   /// adc readout from common mode 1
   int adc_cm1;
 
+  /**
+   * Corruption checks on the data
+   *
+   * Index | Description
+   * ------|-------------
+   *  0    | header leading four bits are wrong
+   *  1    | CRC does not match
+   *  2    | error present in one of the counters
+   *  3    | error present in first quarter (ch0-17 and cm)
+   *  4    | error present in second quarter (calib and ch18-35)
+   *  5    | header trailing four bits are wrong
+   */
+  std::array<bool, 6> corruption;
+
   /// array of samples from the channels
   std::array<Sample, 36> channels;
+
   /// sample from calibration channel
   Sample calib;
 

--- a/include/pflib/packing/DAQLinkFrame.h
+++ b/include/pflib/packing/DAQLinkFrame.h
@@ -27,8 +27,6 @@ class DAQLinkFrame {
   int event;
   /// orbit id number
   int orbit;
-  /// flag if this is the first event
-  bool first_event;
   /// adc readout from common mode 0
   int adc_cm0;
   /// adc readout from common mode 1

--- a/include/pflib/packing/DAQLinkFrame.h
+++ b/include/pflib/packing/DAQLinkFrame.h
@@ -43,8 +43,9 @@ class DAQLinkFrame {
    *  3    | error present in first quarter (ch0-17 and cm)
    *  4    | error present in second quarter (calib and ch18-35)
    *  5    | header trailing four bits are wrong
+   *  6    | common mode leading 12 bits are wrong
    */
-  std::array<bool, 6> corruption;
+  std::array<bool, 7> corruption;
 
   /// array of samples from the channels
   std::array<Sample, 36> channels;
@@ -67,7 +68,7 @@ class DAQLinkFrame {
    */
   DAQLinkFrame(std::span<uint32_t> data);
 
-  /// default constructor that does not do anything:w
+  /// default constructor that does not do anything
   DAQLinkFrame() = default;
 };
 

--- a/include/pflib/utility.h
+++ b/include/pflib/utility.h
@@ -3,6 +3,8 @@
  */
 #include <functional>
 #include <string>
+#include <cstdint>
+#include <span>
 
 namespace pflib {
 
@@ -29,5 +31,13 @@ void loadIntegerCSV(const std::string& file_name,
  * @return true if full's last characters match ending
  */
 bool endsWith(const std::string& full, const std::string& ending);
+
+/**
+ * Calculate the CRC checksum
+ *
+ * @param[in] data 32-bit words to calculate CRC for
+ * @return value of CRC
+ */
+uint32_t crc(std::span<uint32_t> data);
 
 }  // namespace pflib

--- a/justfile
+++ b/justfile
@@ -45,3 +45,6 @@ clean:
 hexdump *args:
     hexdump -v -e '1/4 "%08x" "\n"' {{ args }}
    
+# run the decoder
+decode *args:
+    denv ./build/pfdecoder {{ args }}

--- a/src/pflib/packing/DAQLinkFrame.cxx
+++ b/src/pflib/packing/DAQLinkFrame.cxx
@@ -35,10 +35,10 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
   corruption[3] = ((header >> (1 + 4)) & mask<1>) == 1;
   corruption[4] = ((header >> (4)) & mask<1>) == 1;
   uint32_t trailflag = (header & mask<4>);
-  corruption[5] = (trailflag != 0b0101);
+  corruption[5] = (trailflag != 0b0101 and trailflag != 0b0010 );
   if (corruption[5]) {
     pflib_log(trace)
-        << "bad trailing 4 bits of header (0b0101): "
+        << "bad trailing 4 bits of header (0b0101 or 0b0010): "
         << std::bitset<4>(trailflag);
   }
 

--- a/src/pflib/packing/DAQLinkFrame.cxx
+++ b/src/pflib/packing/DAQLinkFrame.cxx
@@ -25,8 +25,8 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
   uint32_t leading = (header >> (12 + 6 + 3 + 1 + 1 + 1 + 4)) & mask<4>;
   corruption[0] = (leading != 0b1111 and leading != 0b0101);
   if (corruption[0]) {
-    pflib_log(warn) << "bad leading 4-bits of header (0b1111 or 0b0101): "
-                    << std::bitset<4>(leading);
+    pflib_log(trace) << "bad leading 4-bits of header (0b1111 or 0b0101): "
+                     << std::bitset<4>(leading);
   }
   bx = (header >> (6 + 3 + 1 + 1 + 1 + 4)) & mask<12>;
   event = (header >> (3 + 1 + 1 + 1 + 4)) & mask<6>;
@@ -37,7 +37,7 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
   uint32_t trailflag = (header & mask<4>);
   corruption[5] = (trailflag != 0b0101);
   if (corruption[5]) {
-    pflib_log(warn)
+    pflib_log(trace)
         << "bad trailing 4 bits of header (0b0101): "
         << std::bitset<4>(trailflag);
   }

--- a/src/pflib/packing/DAQLinkFrame.cxx
+++ b/src/pflib/packing/DAQLinkFrame.cxx
@@ -21,7 +21,7 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
   }
 
   const uint32_t& header = data[0];
-  pflib_log(trace) << "daq link header " << hex(header);
+  pflib_log(trace) << hex(header) << " daq link header";
   uint32_t leading = (header >> (12 + 6 + 3 + 1 + 1 + 1 + 4)) & mask<4>;
   corruption[0] = (leading != 0b1111 and leading != 0b0101);
   if (corruption[0]) {
@@ -43,8 +43,9 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
   }
 
   const uint32_t& cm{data[1]};
-  pflib_log(trace) << "common mode " << hex(cm);
-  if (((cm >> 20) & mask<12>) != 0) {
+  pflib_log(trace) << hex(cm) << " common mode word";
+  corruption[6] = (((cm >> 20) & mask<12>) != 0);
+  if (corruption[6]) {
     // these leading bits are ignored in the CMS hexactrl-sw decoding
     // so we are going to ignore them here putting 
     pflib_log(trace) << "bad common mode leading 12 bits (should be all zero): "
@@ -56,12 +57,33 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
   std::size_t i_chan{0};
   for (; i_chan < 18; i_chan++) {
     channels[i_chan].word = data[2 + i_chan];
+    pflib_log(trace) << hex(channels[i_chan].word) << " -> ch " << i_chan
+                     << " Tp = " << std::boolalpha << channels[i_chan].Tp()
+                     << " Tc = " << std::boolalpha << channels[i_chan].Tc()
+                     << " adc = " << channels[i_chan].adc()
+                     << " adc_tm1 = " << channels[i_chan].adc_tm1()
+                     << " tot = " << channels[i_chan].tot()
+                     << " toa = " << channels[i_chan].toa();
   }
 
   calib.word = data[2 + 18];
+  pflib_log(trace) << hex(calib.word) << " -> calib"
+                   << " Tp = " << std::boolalpha << calib.Tp()
+                   << " Tc = " << std::boolalpha << calib.Tc()
+                   << " adc = " << calib.adc()
+                   << " adc_tm1 = " << calib.adc_tm1()
+                   << " tot = " << calib.tot()
+                   << " toa = " << calib.toa();
 
   for (; i_chan < 36; i_chan++) {
     channels[i_chan].word = data[2 + 1 + i_chan];
+    pflib_log(trace) << hex(channels[i_chan].word) << " -> ch " << i_chan
+                     << " Tp = " << std::boolalpha << channels[i_chan].Tp()
+                     << " Tc = " << std::boolalpha << channels[i_chan].Tc()
+                     << " adc = " << channels[i_chan].adc()
+                     << " adc_tm1 = " << channels[i_chan].adc_tm1()
+                     << " tot = " << channels[i_chan].tot()
+                     << " toa = " << channels[i_chan].toa();
   }
 
   /**

--- a/src/pflib/packing/DAQLinkFrame.cxx
+++ b/src/pflib/packing/DAQLinkFrame.cxx
@@ -24,11 +24,11 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
 
   const uint32_t& header = data[0];
   pflib_log(trace) << "daq link header " << hex(header);
-  uint32_t allones = (header >> (12 + 6 + 3 + 1 + 1 + 1 + 4)) & mask<4>;
-  corruption[0] = (allones != 0b1111);
+  uint32_t leading = (header >> (12 + 6 + 3 + 1 + 1 + 1 + 4)) & mask<4>;
+  corruption[0] = (leading != 0b1111 and leading != 0b0101);
   if (corruption[0]) {
-    pflib_log(warn) << "bad leading header bits (should be all ones): "
-                    << std::bitset<4>(allones);
+    pflib_log(warn) << "bad leading 4-bits of header (0b1111 or 0b0101): "
+                    << std::bitset<4>(leading);
   }
   bx = (header >> (6 + 3 + 1 + 1 + 1 + 4)) & mask<12>;
   event = (header >> (3 + 1 + 1 + 1 + 4)) & mask<6>;
@@ -37,18 +37,17 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
   corruption[3] = ((header >> (1 + 4)) & mask<1>) == 1;
   corruption[4] = ((header >> (4)) & mask<1>) == 1;
   uint32_t trailflag = (header & mask<4>);
-  first_event = (trailflag == 0b0010);
-  corruption[5] = (not first_event and trailflag != 0b0101);
+  corruption[5] = (trailflag != 0b0101);
   if (corruption[5]) {
     pflib_log(warn)
-        << "bad event header flag (0b0101 or 0b0010 for first event): "
+        << "bad trailing 4 bits of header (0b0101): "
         << std::bitset<4>(trailflag);
   }
 
   const uint32_t& cm{data[1]};
   if (((cm >> 20) & mask<12>) != 0) {
     // these leading bits are ignored in the CMS hexactrl-sw decoding
-    // so we are going to ignore them here
+    // so we are going to ignore them here putting 
     pflib_log(trace) << "bad common mode leading 12 bits (should be all zero): "
                      << std::bitset<12>(cm >> 20);
   }
@@ -74,7 +73,8 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
   std::transform( crc_inputs.begin(), crc_inputs.end(), crc_inputs.begin(),
     [](uint32_t w) { return boost::endian::endian_reverse(w); });
   auto input_ptr = reinterpret_cast<const unsigned char*>(crc_inputs.data());
-  auto crc32 = boost::crc<32, 0x4c11db7, 0x0, 0x0, false, false>(input_ptr, 39*4);
+  // bits, truncation polynomial, initial value, final xor, reflect input, reflect output
+  auto crc32 = boost::crc<32, 0x04c11db7, 0x0, 0x0, false, false>(input_ptr, 39*4);
   uint32_t target = data[39];
   corruption[1] = (crc32 != target);
   /* no warning on CRC sum, again like CMS hexactrl-sw

--- a/src/pflib/packing/DAQLinkFrame.cxx
+++ b/src/pflib/packing/DAQLinkFrame.cxx
@@ -4,6 +4,9 @@
 #include <iostream>
 #include <sstream>
 
+#include <boost/endian/conversion.hpp>
+#include <boost/crc.hpp>
+
 #include "pflib/packing/Hex.h"
 
 namespace pflib::packing {
@@ -22,19 +25,21 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
   const uint32_t& header = data[0];
   pflib_log(trace) << "daq link header " << hex(header);
   uint32_t allones = (header >> (12 + 6 + 3 + 1 + 1 + 1 + 4)) & mask<4>;
-  if (allones != 0b1111) {
+  corruption[0] = (allones != 0b1111);
+  if (corruption[0]) {
     pflib_log(warn) << "bad leading header bits (should be all ones): "
                     << std::bitset<4>(allones);
   }
   bx = (header >> (6 + 3 + 1 + 1 + 1 + 4)) & mask<12>;
   event = (header >> (3 + 1 + 1 + 1 + 4)) & mask<6>;
   orbit = (header >> (1 + 1 + 1 + 4)) & mask<3>;
-  counter_err = ((header >> (1 + 1 + 4)) & mask<1>) == 1;
-  first_quarter_err = ((header >> (1 + 4)) & mask<1>) == 1;
-  second_quarter_err = ((header >> (4)) & mask<1>) == 1;
+  corruption[2] = ((header >> (1 + 1 + 4)) & mask<1>) == 1;
+  corruption[3] = ((header >> (1 + 4)) & mask<1>) == 1;
+  corruption[4] = ((header >> (4)) & mask<1>) == 1;
   uint32_t trailflag = (header & mask<4>);
-  first_event = (trailflag == 0b0101);
-  if (not first_event and trailflag != 0b0010) {
+  first_event = (trailflag == 0b0010);
+  corruption[5] = (not first_event and trailflag != 0b0101);
+  if (corruption[5]) {
     pflib_log(warn)
         << "bad event header flag (0b0101 or 0b0010 for first event): "
         << std::bitset<4>(trailflag);
@@ -42,8 +47,10 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
 
   const uint32_t& cm{data[1]};
   if (((cm >> 20) & mask<12>) != 0) {
-    pflib_log(warn) << "bad common mode leading 12 bits (should be all zero): "
-                    << std::bitset<12>(cm >> 20);
+    // these leading bits are ignored in the CMS hexactrl-sw decoding
+    // so we are going to ignore them here
+    pflib_log(trace) << "bad common mode leading 12 bits (should be all zero): "
+                     << std::bitset<12>(cm >> 20);
   }
   adc_cm0 = (cm >> 10) & mask<10>;
   adc_cm1 = cm & mask<10>;
@@ -59,8 +66,22 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
     channels[i_chan].word = data[2 + 1 + i_chan];
   }
 
-  [[maybe_unused]] uint32_t crc_sum = data[39];
-  pflib_log(trace) << "CRC Sum from stream: " << crc_sum;
+  // CMS hexactrl-sw decoding needed to endian-reverse all the words
+  // prior to calculating the CRC here so we have to copy the data into
+  // a new area so we can change the words before processing them through
+  // the CRC calculator
+  std::vector<uint32_t> crc_inputs{data.begin(), data.end()};
+  std::transform( crc_inputs.begin(), crc_inputs.end(), crc_inputs.begin(),
+    [](uint32_t w) { return boost::endian::endian_reverse(w); });
+  auto input_ptr = reinterpret_cast<const unsigned char*>(crc_inputs.data());
+  auto crc32 = boost::crc<32, 0x4c11db7, 0x0, 0x0, false, false>(input_ptr, 39*4);
+  uint32_t target = data[39];
+  corruption[1] = (crc32 != target);
+  /* no warning on CRC sum, again like CMS hexactrl-sw
+  if (corruption[1]) {
+    pflib_log(warn) << "CRC sum don't match " << hex(crc32) << " != " << hex(target);
+  }
+  */
 }
 
 DAQLinkFrame::DAQLinkFrame(std::span<uint32_t> data) { from(data); }

--- a/src/pflib/packing/DAQLinkFrame.cxx
+++ b/src/pflib/packing/DAQLinkFrame.cxx
@@ -43,6 +43,7 @@ void DAQLinkFrame::from(std::span<uint32_t> data) {
   }
 
   const uint32_t& cm{data[1]};
+  pflib_log(trace) << "common mode " << hex(cm);
   if (((cm >> 20) & mask<12>) != 0) {
     // these leading bits are ignored in the CMS hexactrl-sw decoding
     // so we are going to ignore them here putting 

--- a/test/decoding.cxx
+++ b/test/decoding.cxx
@@ -31,6 +31,28 @@ BOOST_AUTO_TEST_CASE(simple_adc) {
   BOOST_CHECK(s.toa() == 3);
 }
 
+BOOST_AUTO_TEST_CASE(high_bits) {
+  pflib::packing::Sample s;
+  s.word = 0b00100000000110000000101000000011;
+  BOOST_CHECK(s.Tc() == false);
+  BOOST_CHECK(s.Tp() == false);
+  BOOST_CHECK(s.adc() == 514);
+  BOOST_CHECK(s.tot() == -1);
+  BOOST_CHECK(s.adc_tm1() == 513);
+  BOOST_CHECK(s.toa() == 515);
+}
+
+BOOST_AUTO_TEST_CASE(real_word_1) {
+  pflib::packing::Sample s;
+  s.word = 0x03012c02;
+  BOOST_CHECK(s.Tc() == false);
+  BOOST_CHECK(s.Tp() == false);
+  BOOST_CHECK(s.adc() == 75);
+  BOOST_CHECK(s.tot() == -1);
+  BOOST_CHECK(s.adc_tm1() == 48);
+  BOOST_CHECK(s.toa() == 2);
+}
+
 BOOST_AUTO_TEST_CASE(tot_output) {
   pflib::packing::Sample s;
   s.word = 0b11000000000100000000100000000011;

--- a/test/decoding.cxx
+++ b/test/decoding.cxx
@@ -95,9 +95,12 @@ BOOST_AUTO_TEST_CASE(foo) {
   BOOST_CHECK(f.bx == 12);
   BOOST_CHECK(f.event == 9);
   BOOST_CHECK(f.orbit == 5);
-  BOOST_CHECK(f.second_quarter_err == false);
-  BOOST_CHECK(f.first_quarter_err == true);
-  BOOST_CHECK(f.counter_err == false);
+  BOOST_CHECK(f.corruption[4] == false);
+  BOOST_CHECK(f.corruption[3] == true);
+  BOOST_CHECK(f.corruption[2] == false);
+  BOOST_CHECK(f.corruption[0] == false);
+  BOOST_CHECK(f.corruption[1] == true);
+  BOOST_CHECK(f.corruption[5] == false);
   BOOST_CHECK(f.adc_cm1 == 2);
   BOOST_CHECK(f.adc_cm0 == 138);
 

--- a/test/decoding.cxx
+++ b/test/decoding.cxx
@@ -4,8 +4,17 @@
 #include "pflib/Exception.h"
 #include "pflib/packing/DAQLinkFrame.h"
 #include "pflib/packing/Sample.h"
+#include "pflib/packing/Mask.h"
 
 BOOST_AUTO_TEST_SUITE(decoding)
+
+BOOST_AUTO_TEST_SUITE(mask)
+
+BOOST_AUTO_TEST_CASE(ten_bits) {
+  BOOST_CHECK_EQUAL(pflib::packing::mask<10>, 0x3ff);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(sample)
 
@@ -51,6 +60,17 @@ BOOST_AUTO_TEST_CASE(real_word_1) {
   BOOST_CHECK(s.tot() == -1);
   BOOST_CHECK(s.adc_tm1() == 48);
   BOOST_CHECK(s.toa() == 2);
+}
+
+BOOST_AUTO_TEST_CASE(real_word_2) {
+  pflib::packing::Sample s;
+  s.word = 0x08208a02;
+  BOOST_CHECK(s.Tc() == false);
+  BOOST_CHECK(s.Tp() == false);
+  BOOST_CHECK_EQUAL(s.adc(), 34);
+  BOOST_CHECK_EQUAL(s.tot(), -1);
+  BOOST_CHECK_EQUAL(s.adc_tm1(), 130);
+  BOOST_CHECK_EQUAL(s.toa(), 514);
 }
 
 BOOST_AUTO_TEST_CASE(tot_output) {

--- a/test/decoding.cxx
+++ b/test/decoding.cxx
@@ -82,8 +82,9 @@ std::vector<uint32_t> gen_test_frame() {
   for (; i_ch < 36; i_ch++) {
     test_frame.push_back(i_ch);
   }
-  // not testing CRC, just put in dummy word
-  test_frame.push_back(0x0f0f0f0f);
+  // CRC word calculated by our own code
+  // just to quiet the testing
+  test_frame.push_back(0xe2378cb3);
   return test_frame;
 }
 
@@ -95,11 +96,11 @@ BOOST_AUTO_TEST_CASE(foo) {
   BOOST_CHECK(f.bx == 12);
   BOOST_CHECK(f.event == 9);
   BOOST_CHECK(f.orbit == 5);
-  BOOST_CHECK(f.corruption[4] == false);
-  BOOST_CHECK(f.corruption[3] == true);
-  BOOST_CHECK(f.corruption[2] == false);
   BOOST_CHECK(f.corruption[0] == false);
-  BOOST_CHECK(f.corruption[1] == true);
+  BOOST_CHECK(f.corruption[1] == false);
+  BOOST_CHECK(f.corruption[2] == false);
+  BOOST_CHECK(f.corruption[3] == true);
+  BOOST_CHECK(f.corruption[4] == false);
   BOOST_CHECK(f.corruption[5] == false);
   BOOST_CHECK(f.adc_cm1 == 2);
   BOOST_CHECK(f.adc_cm0 == 138);

--- a/test/decoding.cxx
+++ b/test/decoding.cxx
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_SUITE(daq_link_frame)
 
 std::vector<uint32_t> gen_test_frame() {
   std::vector<uint32_t> test_frame = {
-      0xf00c26a2,  // daq header
+      0xf00c26a5,  // daq header
       0x00022802,  // common mode
   };
   std::size_t i_ch{0};

--- a/test/utility.cxx
+++ b/test/utility.cxx
@@ -55,4 +55,14 @@ BOOST_AUTO_TEST_CASE(missing_cells) {
 
 BOOST_AUTO_TEST_SUITE_END()
 
+BOOST_AUTO_TEST_SUITE(crc);
+
+BOOST_AUTO_TEST_CASE(increment) {
+  std::vector<uint32_t> data = {0x02};
+  auto result = pflib::crc(data);
+  BOOST_CHECK_EQUAL( result, 0x09823b6e );
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
After some investigation of CMS's [hexactrl-sw](https://gitlab.cern.ch/hgcal-daq-sw/hexactrl-sw), I'm more confident that this implementation yields the same output data as their implementation while their checks for corruption do not print any messages.

We still store whether certain things go wrong in the `DAQLinkFrame.corruption` member variable for folks who want to do more detailed checking, but it seems like we can ignore the main errors we see with regularity (trailing 4-bits of header incorrect, leading 12-bits of common mode incorrect, CRC checksum not matching).