### PR TITLE
Refactor writing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,8 @@ add_library(pflib SHARED
   src/pflib/Target.cxx
   src/pflib/GPIO.cxx
   src/pflib/Elinks.cxx
+  src/pflib/DecodeAndWrite.cxx
+  src/pflib/WriteToBinaryFile.cxx
   src/pflib/lpGBT.cxx
   src/pflib/lpgbt/lpGBT_ConfigTransport_I2C.cxx
   src/pflib/lpgbt/lpGBT_Registers.cxx

--- a/app/pfdecoder.cxx
+++ b/app/pfdecoder.cxx
@@ -130,7 +130,7 @@ int main(int argc, char* argv[]) {
 
   try {
     o << std::boolalpha;
-    o << "link,bx,event,orbit,channel,Tp,Tc,adc_tm1,adc,tot,toa\n";
+    o << pflib::packing::SingleROCEventPacket::to_csv_header << '\n';
   
     pflib::packing::SingleROCEventPacket ep;
     // count is NOT written into output file,

--- a/app/tool/main.cxx
+++ b/app/tool/main.cxx
@@ -878,7 +878,7 @@ static void daq(const std::string& cmd, Target* pft) {
         BaseMenu::readline_bool("Should we decode the packet into CSV?", true);
         
     if (decoding) {
-      pflib::AllChannelsToCSV writer{fname + ".csv"};
+      pflib::DecodeAndWriteToCSV writer{pflib::all_channels_to_csv(fname + ".csv")};
       pft->daq_run(cmd, writer, nevents, rate);
     } else {
       pflib::WriteToBinaryFile writer{fname + ".raw"};
@@ -1361,7 +1361,7 @@ auto menu_daq_debug =
             std::string fname = BaseMenu::readline_path("charge-timein");
             static int rate = 100;
             tgt->setup_run(1, daq_format_mode, daq_contrib_id);
-            pflib::AllChannelsToCSV writer{fname+".csv"};
+            pflib::DecodeAndWriteToCSV writer{pflib::all_channels_to_csv(fname + ".csv")};
             pflib::ROC roc{tgt->hcal().roc(iroc, type_version)};
             auto test_param_handle = roc.testParameters()
               .add("REFERENCEVOLTAGE_1", "CALIB", calib)

--- a/app/tool/main.cxx
+++ b/app/tool/main.cxx
@@ -30,6 +30,9 @@
 #include "pflib/packing/BufferReader.h"
 #include "pflib/packing/SingleROCEventPacket.h"
 #include "pflib/utility.h"
+#include "pflib/DecodeAndWrite.h"
+#include "pflib/WriteToBinaryFile.h"
+
 /**
  * pull the target of our menu into this source file to reduce code
  */
@@ -728,123 +731,6 @@ static std::string start_dma_cmd = "";
 static std::string stop_dma_cmd = "";
 static auto the_log_{pflib::logging::get("pftool")};
 
-/**
- * just copy input event packets to the output file as binary
- */
-class WriteToBinaryFile {
-  std::string file_name_;
-  FILE* fp_;
-
- public:
-  WriteToBinaryFile(const std::string& file_name)
-      : file_name_{file_name}, fp_{fopen(file_name.c_str(), "a")} {
-    if (not fp_) {
-      PFEXCEPTION_RAISE("FileOpen", "Unable to open " + file_name_);
-    }
-  }
-  ~WriteToBinaryFile() {
-    if (fp_) fclose(fp_);
-    fp_ = 0;
-  }
-  void operator()(std::vector<uint32_t>& event) {
-    fwrite(&(event[0]), sizeof(uint32_t), event.size(), fp_);
-  }
-};
-
-/**
- * decode the input with pflib::packing::SingleROCEventPacket and write to CSV
- */
-class DecodeAndWriteToCSV {
-  std::ofstream file_;
-  pflib::packing::SingleROCEventPacket ep_;
-  mutable ::pflib::logging::logger the_log_{
-      pflib::logging::get("DecodeAndWriteToCSV")};
-
- public:
-  DecodeAndWriteToCSV(const std::string& file_name) : file_{file_name} {
-    if (not file_) {
-      PFEXCEPTION_RAISE("FileOpen", "Unable to open " + file_name);
-    }
-    file_ << std::boolalpha;
-    file_ << "link,bx,event,orbit,channel,Tp,Tc,adc_tm1,adc,tot,toa\n";
-  }
-  void operator()(std::vector<uint32_t>& event) {
-    // we have to manually check the size so that we can do the reinterpret_cast
-    if (event.size() == 0) {
-      pflib_log(warn) << "event with zero words read out, skipping";
-      return;
-    }
-    // reinterpret the 32-bit words into a vector of bytes which is
-    // what is consummed by the BufferReader
-    const auto& buffer{*reinterpret_cast<const std::vector<uint8_t>*>(&event)};
-    pflib::packing::BufferReader r{buffer};
-    r >> ep_;
-    ep_.to_csv(file_);
-  }
-};
-
-/**
- * Do a DAQ run using the input target
- *
- * @param[in] pft target to use
- * @param[in] cmd PEDESTAL, CHARGE, or LED (type of trigger to send)
- * @param[in] run run number not currently used in implementation of daq format
- * @param[in] nevents number of events to collect
- * @param[in] rate how fast to collect events, not implemented
- * @param[in] Action function that consumes the event packets and does something with them
- * (presumably writes them out to a file)
- */
-static void daq_run(Target* pft,
-                    const std::string& cmd, int run, int nevents, int rate,
-                    std::function<void(std::vector<uint32_t>&)> Action) {
-  static const
-  std::unordered_map<std::string, std::function<void(pflib::FastControl&)>>
-  cmds = {
-    {"PEDESTAL", [](pflib::FastControl& fc) { fc.sendL1A(); }},
-    {"CHARGE"  , [](pflib::FastControl& fc) { fc.chargepulse(); }},
-    {"LED"     , [](pflib::FastControl& fc) { fc.ledpulse(); }}
-  };
-  if (cmds.find(cmd) == cmds.end()) {
-    PFEXCEPTION_RAISE("UnknownCMD", "Command "+cmd+" is not one of the daq_run options.");
-  }
-  auto trigger{cmds.at(cmd)};
-
-  timeval tv0, tvi;
-  gettimeofday(&tv0, 0);
-  for (int ievt = 0; ievt < nevents; ievt++) {
-    pflib_log(trace) << "daq event occupancy pre-L1A    : "
-                     << pft->hcal().daq().getEventOccupancy();
-    trigger(pft->fc());
-
-    pflib_log(trace) << "daq event occupancy post-L1A   : "
-                     << pft->hcal().daq().getEventOccupancy();
-    gettimeofday(&tvi, 0);
-    double runsec =
-        (tvi.tv_sec - tv0.tv_sec) + (tvi.tv_usec - tv0.tv_usec) / 1e6;
-    double targettime = (ievt + 1.0) / rate;
-    int usec_ahead = int((targettime - runsec) * 1e6);
-    pflib_log(trace) << " at " << runsec << "s instead of " << targettime
-                     << "s aheady by " << usec_ahead << "us";
-    if (usec_ahead > 100) {
-      usleep(usec_ahead);
-    }
-
-    pflib_log(trace) << "daq event occupancy after pause: "
-                     << pft->hcal().daq().getEventOccupancy();
-
-    std::vector<uint32_t> event = pft->read_event();
-    pflib_log(trace) << "daq event occupancy after read : "
-                     << pft->hcal().daq().getEventOccupancy();
-    pflib_log(debug) << "event " << ievt << " has " << event.size()
-                     << " 32-bit words";
-    if (event.size() == 0) {
-      pflib_log(warn) << "event " << ievt
-                      << " did not have any words, skipping.";
-    } else {
-      Action(event);
-    }
-  }
-};
 
 /**
  * DAQ menu commands, DOES NOT include sub-menu commands
@@ -992,11 +878,11 @@ static void daq(const std::string& cmd, Target* pft) {
         BaseMenu::readline_bool("Should we decode the packet into CSV?", true);
         
     if (decoding) {
-      DecodeAndWriteToCSV writer{fname + ".csv"};
-      daq_run(pft, cmd, run, nevents, rate, [&](auto event) { writer(event); });
+      pflib::AllChannelsToCSV writer{fname + ".csv"};
+      pft->daq_run(cmd, writer, nevents, rate);
     } else {
-      WriteToBinaryFile writer{fname + ".raw"};
-      daq_run(pft, cmd, run, nevents, rate, [&](auto event) { writer(event); });
+      pflib::WriteToBinaryFile writer{fname + ".raw"};
+      pft->daq_run(cmd, writer, nevents, rate);
     }
   }
 
@@ -1475,7 +1361,7 @@ auto menu_daq_debug =
             std::string fname = BaseMenu::readline_path("charge-timein");
             static int rate = 100;
             tgt->setup_run(1, daq_format_mode, daq_contrib_id);
-            DecodeAndWriteToCSV writer{fname+".csv"};
+            pflib::AllChannelsToCSV writer{fname+".csv"};
             pflib::ROC roc{tgt->hcal().roc(iroc, type_version)};
             auto test_param_handle = roc.testParameters()
               .add("REFERENCEVOLTAGE_1", "CALIB", calib)
@@ -1487,7 +1373,7 @@ auto menu_daq_debug =
               tgt->fc().fc_setup_calib(toffset);
               usleep(10);
               pflib_log(info) << "run with FAST_CONTROL.CALIB = " << tgt->fc().fc_get_setup_calib();
-              daq_run(tgt, "CHARGE", 1, nevents, rate, [&](auto event) { writer(event); });
+              tgt->daq_run("CHARGE", writer, nevents, rate);
             }
           })
     /*

--- a/include/pflib/DecodeAndWrite.h
+++ b/include/pflib/DecodeAndWrite.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <fstream>
+#include <memory>
+#include <functional>
+
+#include "pflib/packing/SingleROCEventPacket.h"
+#include "pflib/Logging.h"
+#include "pflib/Target.h"
+
+namespace pflib {
+
+/**
+ * Consume an event packet, decode it, and then do something else
+ *
+ * This class holds the event packet for the user so that
+ * other code just needs to write functions that define how the
+ * decoded data should be written out.
+ */
+class DecodeAndWrite : public Target::DAQRunConsumer {
+ public:
+  virtual ~DecodeAndWrite() = default;
+  /**
+   * Decode the input event packet into our pflib::packing::SingleROCEventPacket
+   * and then call write_event on it.
+   */
+  virtual void consume(std::vector<uint32_t>& event) final;
+
+  /// pure virtual function for writing out decoded event
+  virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) = 0;
+
+ private:
+  /// event packet for decoding
+  pflib::packing::SingleROCEventPacket ep_;
+  /// logging for warning messages on empty events
+  mutable ::pflib::logging::logger the_log_;
+};
+
+/**
+ * specializatin of DecodeAndWrite that holds a std::ofstream
+ * for the user with functions for writing the header and events
+ */
+class DecodeAndWriteToCSV : public DecodeAndWrite {
+  /// output file writing to
+  std::ofstream file_;
+  /// function that writes row(s) to csv given an event
+  std::function<void(std::ofstream&, const pflib::packing::SingleROCEventPacket&)> write_event_;
+ public:
+  DecodeAndWriteToCSV(
+    const std::string& file_name,
+    std::function<void(std::ofstream&)> write_header,
+    std::function<void(std::ofstream&, const pflib::packing::SingleROCEventPacket&)> write_event
+  );
+  virtual ~DecodeAndWriteToCSV() = default;
+  /// call write_event with our file handle
+  virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) final;
+};
+
+class AllChannelsToCSV : public DecodeAndWriteToCSV {
+ public:
+  AllChannelsToCSV(const std::string& file_name);
+  virtual ~AllChannelsToCSV() = default;
+};
+
+}

--- a/include/pflib/DecodeAndWrite.h
+++ b/include/pflib/DecodeAndWrite.h
@@ -56,10 +56,6 @@ class DecodeAndWriteToCSV : public DecodeAndWrite {
   virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) final;
 };
 
-class AllChannelsToCSV : public DecodeAndWriteToCSV {
- public:
-  AllChannelsToCSV(const std::string& file_name);
-  virtual ~AllChannelsToCSV() = default;
-};
+DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name);
 
 }

--- a/include/pflib/Target.h
+++ b/include/pflib/Target.h
@@ -25,11 +25,37 @@ class Target {
   virtual std::vector<uint32_t> read_event() = 0;
   virtual bool has_event() { return hcal().daq().getEventOccupancy() > 0; }
 
+  /**
+   * Abstract base class for consuming event packets
+   */
+  class DAQRunConsumer {
+   public:
+    virtual void consume(std::vector<uint32_t>& event) = 0;
+    virtual ~DAQRunConsumer() = default;
+  };
+
+  /**
+   * Do a DAQ run
+   * 
+   * @param[in] cmd PEDESTAL, CHARGE, or LED (type of trigger to send)
+   * @param[in] consumer DAQRunConsumer that handles the readout event packets
+   * (probably writes them to a file or something like that)
+   * @param[in] nevents number of events to collect
+   * @param[in] rate how fast to collect events, default 100
+   */
+  void daq_run(
+      const std::string& cmd,
+      DAQRunConsumer& consumer,
+      int nevents,
+      int rate = 100
+  );
+
  protected:
   std::map<std::string, std::shared_ptr<I2C> > i2c_;
 
   std::shared_ptr<Hcal> hcal_;
   std::shared_ptr<FastControl> fc_;
+  mutable logging::logger the_log_{logging::get("Target")};
 };
 
 Target* makeTargetFiberless();

--- a/include/pflib/WriteToBinaryFile.h
+++ b/include/pflib/WriteToBinaryFile.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <stdio.h>
+
+#include "pflib/Target.h"
+
+namespace pflib {
+
+/**
+ * just copy input event packets to the output file as binary
+ */
+class WriteToBinaryFile : public Target::DAQRunConsumer {
+  std::string file_name_;
+  FILE* fp_;
+ public:
+  WriteToBinaryFile(const std::string& file_name);
+  ~WriteToBinaryFile();
+  virtual void consume(std::vector<uint32_t>& event) final;
+};
+
+}

--- a/include/pflib/packing/Sample.h
+++ b/include/pflib/packing/Sample.h
@@ -22,6 +22,8 @@ struct Sample {
   int adc_tm1() const;
   int adc() const;
   int tot() const;
+  /// header if using to_csv
+  static const std::string to_csv_header;
   /**
    * Write out the Sample as a row in the CSV.
    * ```

--- a/include/pflib/packing/Sample.h
+++ b/include/pflib/packing/Sample.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <fstream>
 
 namespace pflib::packing {
 
@@ -21,6 +22,16 @@ struct Sample {
   int adc_tm1() const;
   int adc() const;
   int tot() const;
+  /**
+   * Write out the Sample as a row in the CSV.
+   * ```
+   * Tp,Tc,adc_tm1,adc,tot,toa
+   * ```
+   * No newline is included in case other columns wish
+   * to be added. If you don't want to include all seven
+   * of these columns, you can write your own method.
+   */
+  void to_csv(std::ofstream& f) const;
 };
 
 }  // namespace pflib::packing

--- a/include/pflib/packing/SingleROCEventPacket.h
+++ b/include/pflib/packing/SingleROCEventPacket.h
@@ -40,6 +40,8 @@ class SingleROCEventPacket {
    * ```
    */
   Reader& read(Reader& r);
+  /// header string if using to_csv
+  static const std::string to_csv_header;
   /**
    * write current packet into a CSV
    *

--- a/src/pflib/DecodeAndWrite.cxx
+++ b/src/pflib/DecodeAndWrite.cxx
@@ -34,17 +34,17 @@ void DecodeAndWriteToCSV::write_event(const pflib::packing::SingleROCEventPacket
   write_event_(file_, ep);
 }
 
-static void all_channels_header(std::ofstream& f) {
-  f << std::boolalpha;
-  f << "link,bx,event,orbit,channel,Tp,Tc,adc_tm1,adc,tot,toa\n";
-}
-
-static void all_channels_write_event(std::ofstream& f, const pflib::packing::SingleROCEventPacket& ep) {
-  ep.to_csv(f);
-}
-
 DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name) {
-  return DecodeAndWriteToCSV(file_name, all_channels_header, all_channels_write_event);
+  return DecodeAndWriteToCSV(
+      file_name,
+      [](std::ofstream& f) {
+        f << std::boolalpha;
+        f << "link,bx,event,orbit,channel,Tp,Tc,adc_tm1,adc,tot,toa\n";
+      },
+      [](std::ofstream& f, const pflib::packing::SingleROCEventPacket& ep) {
+        ep.to_csv(f);
+      }
+  );
 }
 
 }

--- a/src/pflib/DecodeAndWrite.cxx
+++ b/src/pflib/DecodeAndWrite.cxx
@@ -39,7 +39,7 @@ DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name) {
       file_name,
       [](std::ofstream& f) {
         f << std::boolalpha;
-        f << "link,bx,event,orbit,channel,Tp,Tc,adc_tm1,adc,tot,toa\n";
+        f << packing::SingleROCEventPacket::to_csv_header << '\n';
       },
       [](std::ofstream& f, const pflib::packing::SingleROCEventPacket& ep) {
         ep.to_csv(f);

--- a/src/pflib/DecodeAndWrite.cxx
+++ b/src/pflib/DecodeAndWrite.cxx
@@ -1,0 +1,49 @@
+#include "pflib/DecodeAndWrite.h"
+
+#include "pflib/packing/BufferReader.h"
+#include "pflib/Exception.h"
+
+namespace pflib {
+
+void DecodeAndWrite::consume(std::vector<uint32_t>& event) {
+  // we have to manually check the size so that we can do the reinterpret_cast
+  if (event.size() == 0) {
+    pflib_log(warn) << "event with zero words passed in, skipping";
+    return;
+  }
+  // reinterpret the 32-bit words into a vector of bytes which is
+  // what is consummed by the BufferReader
+  const auto& buffer{*reinterpret_cast<const std::vector<uint8_t>*>(&event)};
+  pflib::packing::BufferReader r{buffer};
+  r >> ep_;
+  write_event(ep_);
+}
+
+DecodeAndWriteToCSV::DecodeAndWriteToCSV(
+    const std::string& file_name,
+    std::function<void(std::ofstream&)> write_header,
+    std::function<void(std::ofstream& f, const pflib::packing::SingleROCEventPacket&)> write_event
+) : DecodeAndWrite(), file_{file_name}, write_event_{write_event} {
+  if (not file_) {
+    PFEXCEPTION_RAISE("FileOpen", "unable to open "+file_name+" for writing");
+  }
+  write_header(file_);
+}
+
+void DecodeAndWriteToCSV::write_event(const pflib::packing::SingleROCEventPacket& ep) {
+  write_event_(file_, ep);
+}
+
+static void all_channels_header(std::ofstream& f) {
+  f << std::boolalpha;
+  f << "link,bx,event,orbit,channel,Tp,Tc,adc_tm1,adc,tot,toa\n";
+}
+
+static void all_channels_write_event(std::ofstream& f, const pflib::packing::SingleROCEventPacket& ep) {
+  ep.to_csv(f);
+}
+
+AllChannelsToCSV::AllChannelsToCSV(const std::string& file_name)
+  : DecodeAndWriteToCSV(file_name, all_channels_header, all_channels_write_event) {}
+
+}

--- a/src/pflib/DecodeAndWrite.cxx
+++ b/src/pflib/DecodeAndWrite.cxx
@@ -43,7 +43,8 @@ static void all_channels_write_event(std::ofstream& f, const pflib::packing::Sin
   ep.to_csv(f);
 }
 
-AllChannelsToCSV::AllChannelsToCSV(const std::string& file_name)
-  : DecodeAndWriteToCSV(file_name, all_channels_header, all_channels_write_event) {}
+DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name) {
+  return DecodeAndWriteToCSV(file_name, all_channels_header, all_channels_write_event);
+}
 
 }

--- a/src/pflib/Target.cxx
+++ b/src/pflib/Target.cxx
@@ -1,5 +1,7 @@
 #include "pflib/Target.h"
 
+#include <sys/time.h>
+
 namespace pflib {
 
 std::vector<std::string> Target::i2c_bus_names() {
@@ -9,5 +11,60 @@ std::vector<std::string> Target::i2c_bus_names() {
 }
 
 I2C& Target::get_i2c_bus(const std::string& name) { return *(i2c_[name]); }
+
+void Target::daq_run(
+    const std::string& cmd,
+    DAQRunConsumer& consumer,
+    int nevents,
+    int rate
+) {
+  static const
+  std::unordered_map<std::string, std::function<void(pflib::FastControl&)>>
+  cmds = {
+    {"PEDESTAL", [](pflib::FastControl& fc) { fc.sendL1A(); }},
+    {"CHARGE"  , [](pflib::FastControl& fc) { fc.chargepulse(); }},
+    {"LED"     , [](pflib::FastControl& fc) { fc.ledpulse(); }}
+  };
+  if (cmds.find(cmd) == cmds.end()) {
+    PFEXCEPTION_RAISE("UnknownCMD", "Command "+cmd+" is not one of the daq_run options.");
+  }
+  auto trigger{cmds.at(cmd)};
+
+  timeval tv0, tvi;
+  gettimeofday(&tv0, 0);
+  for (int ievt = 0; ievt < nevents; ievt++) {
+    pflib_log(trace) << "daq event occupancy pre-L1A    : "
+                     << this->hcal().daq().getEventOccupancy();
+    trigger(this->fc());
+
+    pflib_log(trace) << "daq event occupancy post-L1A   : "
+                     << this->hcal().daq().getEventOccupancy();
+    gettimeofday(&tvi, 0);
+    double runsec =
+        (tvi.tv_sec - tv0.tv_sec) + (tvi.tv_usec - tv0.tv_usec) / 1e6;
+    double targettime = (ievt + 1.0) / rate;
+    int usec_ahead = int((targettime - runsec) * 1e6);
+    pflib_log(trace) << " at " << runsec << "s instead of " << targettime
+                     << "s aheady by " << usec_ahead << "us";
+    if (usec_ahead > 100) {
+      usleep(usec_ahead);
+    }
+
+    pflib_log(trace) << "daq event occupancy after pause: "
+                     << this->hcal().daq().getEventOccupancy();
+
+    std::vector<uint32_t> event = this->read_event();
+    pflib_log(trace) << "daq event occupancy after read : "
+                     << this->hcal().daq().getEventOccupancy();
+    pflib_log(debug) << "event " << ievt << " has " << event.size()
+                     << " 32-bit words";
+    if (event.size() == 0) {
+      pflib_log(warn) << "event " << ievt
+                      << " did not have any words, skipping.";
+    } else {
+      consumer.consume(event);
+    }
+  }
+}
 
 }  // namespace pflib

--- a/src/pflib/WriteToBinaryFile.cxx
+++ b/src/pflib/WriteToBinaryFile.cxx
@@ -1,0 +1,20 @@
+#include "pflib/WriteToBinaryFile.h"
+
+namespace pflib {
+
+WriteToBinaryFile::WriteToBinaryFile(const std::string& file_name)
+    : file_name_{file_name}, fp_{fopen(file_name.c_str(), "a")} {
+  if (not fp_) {
+    PFEXCEPTION_RAISE("FileOpen", "Unable to open " + file_name_);
+  }
+}
+WriteToBinaryFile::~WriteToBinaryFile() {
+  if (fp_) fclose(fp_);
+  fp_ = 0;
+}
+
+void WriteToBinaryFile::consume(std::vector<uint32_t>& event) {
+  fwrite(&(event[0]), sizeof(uint32_t), event.size(), fp_);
+}
+
+}

--- a/src/pflib/packing/Sample.cxx
+++ b/src/pflib/packing/Sample.cxx
@@ -36,6 +36,9 @@ int Sample::tot() const {
   }
 }
 
+const std::string Sample::to_csv_header =
+  "Tp,Tc,adc_tm1,adc,tot,toa";
+
 void Sample::to_csv(std::ofstream& f) const {
   f << Tp() << ',' << Tc() << ','
     << adc_tm1() << ',' << adc() << ',' << tot() << ',' << toa();

--- a/src/pflib/packing/Sample.cxx
+++ b/src/pflib/packing/Sample.cxx
@@ -36,4 +36,9 @@ int Sample::tot() const {
   }
 }
 
+void Sample::to_csv(std::ofstream& f) const {
+  f << Tp() << ',' << Tc() << ','
+    << adc_tm1() << ',' << adc() << ',' << tot() << ',' << toa();
+}
+
 }  // namespace pflib::packing

--- a/src/pflib/packing/SingleROCEventPacket.cxx
+++ b/src/pflib/packing/SingleROCEventPacket.cxx
@@ -87,6 +87,9 @@ Reader& SingleROCEventPacket::read(Reader& r) {
   return r;
 }
 
+const std::string SingleROCEventPacket::to_csv_header =
+  "i_link,bx,event,orbit,channel,"+Sample::to_csv_header;
+
 void SingleROCEventPacket::to_csv(std::ofstream& f) const {
   /**
    * The columns of the output CSV are

--- a/src/pflib/packing/SingleROCEventPacket.cxx
+++ b/src/pflib/packing/SingleROCEventPacket.cxx
@@ -102,17 +102,14 @@ void SingleROCEventPacket::to_csv(std::ofstream& f) const {
   for (std::size_t i_link{0}; i_link < 2; i_link++) {
     const auto& daq_link{daq_links[i_link]};
     f << i_link << ',' << daq_link.bx << ',' << daq_link.event << ','
-      << daq_link.orbit << ',' << "calib," << daq_link.calib.Tp() << ','
-      << daq_link.calib.Tc() << ',' << daq_link.calib.adc_tm1() << ','
-      << daq_link.calib.adc() << ',' << daq_link.calib.tot() << ','
-      << daq_link.calib.toa() << '\n';
+      << daq_link.orbit << ',' << "calib,";
+    daq_link.calib.to_csv(f);
+    f << '\n';
     for (std::size_t i_ch{0}; i_ch < 36; i_ch++) {
       f << i_link << ',' << daq_link.bx << ',' << daq_link.event << ','
-        << daq_link.orbit << ',' << i_ch << ',' << daq_link.channels[i_ch].Tp()
-        << ',' << daq_link.channels[i_ch].Tc() << ','
-        << daq_link.channels[i_ch].adc_tm1() << ','
-        << daq_link.channels[i_ch].adc() << ',' << daq_link.channels[i_ch].tot()
-        << ',' << daq_link.channels[i_ch].toa() << '\n';
+        << daq_link.orbit << ',' << i_ch << ',';
+      daq_link.channels[i_ch].to_csv(f);
+      f << '\n';
     }
   }
 }


### PR DESCRIPTION
This refactors how we are writing out our data with a focus on making it easier to implement new methods. Specifically, there are many places where a new writing method could be defined so that shared boiler-plate code can be avoided.

- `daq_run` moved into `Target::daq_run` and uses a `DAQRunConsumer` reference to call `DAQRunConsumer::consume`
- `WriteToBinaryFile` is a `DAQRunConsumer` that writes the data packet directly to a file
- `DecodeAndWrite` is a `DAQRunConsumer` that decodes the data packet into a `SingleROCEventPacket` and then calls `write_event` with the decoded packet
- `DecodeAndWriteToCSV` is a `DecodeAndWrite` that also opens a `std::ofstream` for writing out a text file. It has two free-function callbacks `write_header` which is called once after opening the file and `write_event` which is given the file and the decoded event packet for writing the row(s) to the CSV
- `AllChannelsToCSV` is a `DecodeAndWriteToCSV` that gives examples for `write_header` and `write_event`

Not implemented, but possible with this infrastructure
- Inherit from `DAQRunConsumer` that forwards the packet along the wire to some other server
- Inherit from `DecodeAndWrite` to write decoded data to some other file format (e.g. ROOT, HDF5, Parquet, JSON, ...)

I chose to have `write_header` and `write_event` be free functions so users could inherit pre-declared variables into them allowing (for example) `write_event` to write additional columns that aren't necessarily in the decoded event packet (for example, a parameter setting on the chip being scanned).