### PR TITLE
internal pulse time scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tool/test-menu
 
 # python venv for lightweight analyses
 venv
+# python cache files
+__pycache__

--- a/ana/charge/time-scan.py
+++ b/ana/charge/time-scan.py
@@ -1,0 +1,49 @@
+"""plot the pulse gathered from a time-scan run"""
+
+import update_path
+
+from pathlib import Path
+import argparse
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from read import read_pflib_csv
+
+parser = argparse.ArgumentParser()
+parser.add_argument('time_scan', type=Path, help='time scan data, only one event per time point')
+parser.add_argument('-o','--output', type=Path, help='file to which to print, default is input file with extension changed to ".png"')
+args = parser.parse_args()
+
+if args.output is None:
+    args.output = args.time_scan.with_suffix(".png")
+
+def plt_pulse(
+    samples,
+    time = 'time',
+    amplitude = 'adc',
+    set_xticks = True,
+    ax = None,
+    **kwargs
+):
+    df = samples.sort_values(by=time)
+    if ax is None:
+        ax = plt.gca()
+    art = ax.plot(df[time], df[amplitude], **kwargs)
+    if set_xticks:
+        xmin, xmax = df[time].min(), df[time].max()
+        xmin = 25*np.floor(xmin/25)
+        xmax = 25*np.ceil(xmax/25)
+        ax.set_xticks(ticks = np.arange(xmin, xmax+1, 25), minor=False)
+        ax.set_xticks(ticks = np.arange(xmin, xmax, 25/16), minor=True)
+    return art
+
+samples, run_params = read_pflib_csv(args.time_scan)
+samples['time'] = (samples.charge_to_l1a - 20 + 1)*25 - samples.phase_strobe*25/16
+plt_pulse(samples, label='ADC')
+plt.xlabel('time / ns = (charge_to_l1a - 20 + 1)*25 - samples.phase_strobe*25/16')
+plt.ylabel('ADC')
+plt.title(' '.join([f'{key} = {val}' for key, val in run_params.items()]))
+plt.grid()
+plt.savefig(args.output, bbox_inches='tight')
+plt.clf()

--- a/ana/charge/update_path.py
+++ b/ana/charge/update_path.py
@@ -1,0 +1,12 @@
+"""add the pflib/ana directory to the sys.path so its modules can be found
+
+e.g.
+
+    from read import read_pflib_csv
+
+works after updating the path like this.
+"""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))

--- a/ana/read.py
+++ b/ana/read.py
@@ -1,0 +1,39 @@
+"""reading data output by pflib"""
+
+import json
+import pandas as pd
+
+def read_pflib_csv(fp, **kwargs):
+    """read a "pflib CSV" file into memory
+
+    A "pflib CSV" file is just a CSV file with (optionally) an additional
+    line at the top specifying additional run parameters.
+    This line begins with `#` and then contains the run parameters serialized
+    as a single-line JSON dictionary.
+
+    Parameters
+    ----------
+    fp: str | pathlib.Path
+        filepath to pflib CSV to load
+    kwargs: dict[str,Any]
+        additional key-word arguments given to pd.read_csv
+
+    Returns
+    -------
+    pandas.DataFrame, dict
+        2-tuple containing the pd.DataFrame of the CSV data
+        and a dictionary of the run parameters from the header
+        if no header was included, then the run_parameters dictionary is empty
+    """
+    with open(fp) as f:
+        header = f.readline().strip('\n')
+    has_pflib_header = header[0] == '#'
+    run_params = (
+        json.loads(header.strip('#'))
+        if has_pflib_header else
+        {}
+    )
+    if has_pflib_header:
+        kwargs['skiprows'] = 1
+    data = pd.read_csv(fp, **kwargs)
+    return data, run_params

--- a/app/tool/main.cxx
+++ b/app/tool/main.cxx
@@ -51,6 +51,42 @@ using BaseMenu = pflib::menu::BaseMenu;
 static auto the_log_{pflib::logging::get("pftool")};
 
 /**
+ * Backport of C++20 std::format-like function
+ *
+ * I say "std::format-like" because instead of using curly-braces `{}`
+ * for inserting the arguments like std::format does, this function uses
+ * the C-style (printf-style) percent-characters (e.g. `%s` to insert a string).
+ *
+ * (Supported in GCC-13 and we have GCC-11)
+ *
+ * We basically write to a char* and then conver that to std::string.
+ *
+ * @tparam Args types of arguments passed into snprintf
+ * @param[in] format snprintf format string to use
+ * @param[in] args arguments for snprintf
+ * @return formatted std::string
+ *
+ * Shamelessly taken from https://stackoverflow.com/a/26221725
+ * which has a line-by-line explanation for those who wish to learn more C++!
+ * I've modified it slightly to use our exceptions and longer variable names.
+ */
+template<typename ... Args>
+std::string string_format(const std::string& format, Args ... args) {
+  // length of string without the closing null byte \0
+  int size_s = std::snprintf(nullptr, 0, format.c_str(), args...);
+  if (size_s < 0) {
+    PFEXCEPTION_RAISE("string_format", "error during formating of string "+format);
+  }
+  // need one larger for the closing null byte
+  auto size = static_cast<std::size_t>(size_s + 1);
+  std::unique_ptr<char[]> buffer(new char[size]);
+  // do format again, but this time we know the size and that it works!
+  std::snprintf(buffer.get(), size, format.c_str(), args...);
+  // remove trailing null byte when copying into std::string
+  return std::string(buffer.get(), buffer.get() + size - 1);
+}
+
+/**
  * Execute a command and capture its output into a string
  *
  * The maximum output is 128 characters.
@@ -1359,25 +1395,28 @@ auto menu_task =
         ->line("CHARGE_TIMESCAN", "scan charge/calib pulse over time", [](Target* tgt) {
           int nevents = BaseMenu::readline_int("How many events per time point? ", 100);
           int calib = BaseMenu::readline_int("Setting for calib pulse amplitude? ", 1024);
+          int channel = BaseMenu::readline_int("Channel to pulse into? ", 61);
           std::string fname = BaseMenu::readline_path("charge-time-scan", ".csv");
           static int rate = 100; // pretty fast without overwhelming chip
           static int run = 1; // dummy, not stored
           pflib::ROC roc{tgt->hcal().roc(iroc, type_version)};
+          auto channel_page = string_format("CH_%d", channel);
           auto test_param_handle = roc.testParameters()
             .add("REFERENCEVOLTAGE_1", "CALIB", calib)
             .add("REFERENCEVOLTAGE_1", "INTCTEST", 1)
-            .add("CH_61", "HIGHRANGE", 0)
-            .add("CH_61", "LOWRANGE", 1)
+            .add(channel_page, "HIGHRANGE", 0)
+            .add(channel_page, "LOWRANGE", 1)
             .apply();
           int phase_strobe{0};
           int charge_to_l1a{0};
-          int channel{61};
           pflib::DecodeAndWriteToCSV writer{
             fname,
             [&](std::ofstream& f) {
               f << std::boolalpha
-                << "# data collected from channel " << channel << "\n"
-                << "charge_to_l1a,phase_strobe,Tp,Tc,adc_tm1,adc,tot,toa\n";
+                << "# data collected from channel " << channel << '\n'
+                << "charge_to_l1a,phase_strobe,"
+                << pflib::packing::Sample::to_csv_header
+                << '\n';
             },
             [&](std::ofstream& f, const pflib::packing::SingleROCEventPacket& ep) {
               auto sample{ep.channel(channel)};

--- a/include/pflib/packing/SingleROCEventPacket.h
+++ b/include/pflib/packing/SingleROCEventPacket.h
@@ -48,6 +48,16 @@ class SingleROCEventPacket {
    * @param[in,out] f file to write CSV to
    */
   void to_csv(std::ofstream& f) const;
+  /**
+   * Get a specific Sample from a channel
+   *
+   * The channel index input here is relative to the ROC
+   * [0,72). If you have the channel index within a daq
+   * link (or ROC "half"), just access the daq links directly
+   * ```cpp
+   * ep.daq_links[i_link]
+   */
+  Sample channel(int ch) const;
   /// default constructor that does nothing
   SingleROCEventPacket() = default;
 };

--- a/include/pflib/packing/SingleROCEventPacket.h
+++ b/include/pflib/packing/SingleROCEventPacket.h
@@ -52,10 +52,13 @@ class SingleROCEventPacket {
    * Get a specific Sample from a channel
    *
    * The channel index input here is relative to the ROC
-   * [0,72). If you have the channel index within a daq
+   * [0,71]. If you have the channel index within a daq
    * link (or ROC "half"), just access the daq links directly
    * ```cpp
-   * ep.daq_links[i_link]
+   * ep.daq_links[i_link].channels[i_chan]
+   * ```
+   * where `i_link` is the link index 0 or 1 and `i_chan` is
+   * the channel index within the link [0,35].
    */
   Sample channel(int ch) const;
   /// default constructor that does nothing

--- a/src/pflib/packing/SingleROCEventPacket.cxx
+++ b/src/pflib/packing/SingleROCEventPacket.cxx
@@ -117,4 +117,10 @@ void SingleROCEventPacket::to_csv(std::ofstream& f) const {
   }
 }
 
+Sample SingleROCEventPacket::channel(int ch) const {
+  int i_link = (ch / 36);
+  int i_ch_in_link = (ch % 36);
+  return daq_links[i_link].channels[i_ch_in_link];
+}
+
 }  // namespace pflib::packing


### PR DESCRIPTION
Besides implementing this time scan command, I also

- add accessor to `pflib::packing::SingleROCEventPacket` that access samples by ROC channel number (`[0,72)`)
- introduced a `string_format` function to produce `std::string` from arguments like those for `snprintf`
- introduced Boost.JSON for writing out a header into the output files, I'm thinking we write a single-line header of the form `# <json>` that holds run-wide parameters for the CSV. I demonstrate that in this new command by writing out the pulse height and channel

Parsing this "pflib CSV" (a name I made up) in Python would then look like
```python
import json
import pandas as pd

def read_pflib_csv(
    fp,
    **kwargs
):
    with open(fp) as f:
        header = f.readline().strip('\n')
    has_pflib_header = header[0] == '#'
    run_params = (
        json.loads(header.strip('#'))
        if has_pflib_header else
        None
    )
    if has_pflib_header:
        kwargs['skiprows'] = 1
    data = pd.read_csv(fp, **kwargs)
    return data, run_params
```
so we got both the row-by-row data in a `pandas.DataFrame` and a `dict` of the run parameters written to the header.