### PR TITLE
TASKS.GEN_SCAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ add_library(utility SHARED
   src/pflib/utility/ends_with.cxx
   src/pflib/utility/load_integer_csv.cxx
   src/pflib/utility/json.cxx
+  src/pflib/utility/str_to_int.cxx
 )
 target_include_directories(utility PUBLIC 
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"

--- a/app/tool/daq.cxx
+++ b/app/tool/daq.cxx
@@ -326,7 +326,7 @@ auto menu_daq_debug =
             std::string fname = pftool::readline_path("charge-timein");
             tgt->setup_run(1, DAQ_FORMAT_SIMPLEROC, pftool::state.daq_contrib_id);
             pflib::DecodeAndWriteToCSV writer{pflib::all_channels_to_csv(fname + ".csv")};
-            pflib::ROC roc{tgt->hcal().roc(pftool::state.iroc, pftool::state.type_version)};
+            pflib::ROC roc{tgt->hcal().roc(pftool::state.iroc, pftool::state.type_version())};
             auto test_param_handle = roc.testParameters()
               .add("REFERENCEVOLTAGE_1", "CALIB", calib)
               .add("REFERENCEVOLTAGE_1", "INTCTEST", 1)

--- a/app/tool/main.cxx
+++ b/app/tool/main.cxx
@@ -9,8 +9,45 @@
 
 #include "pflib/menu/Rcfile.h"
 #include "pflib/version/Version.h"
+#include "pflib/Compile.h"
 
 #include "pftool.h"
+
+pftool::State::State() {
+  update_type_version("sipm_rocv3b");
+}
+
+void pftool::State::update_type_version(const std::string& type_version) {
+  if (type_version != type_version_) {
+    page_names_.clear();
+    param_names_.clear();
+    auto defs = pflib::Compiler::get(type_version).defaults();
+    for (const auto& page : defs) {
+      page_names_.push_back(page.first);
+      for (const auto& param : page.second) {
+        param_names_[page.first].push_back(param.first);
+      }
+    }
+  }
+  type_version_ = type_version;
+}
+
+const std::string& pftool::State::type_version() const {
+  return type_version_;
+}
+
+const std::vector<std::string>& pftool::State::page_names() const {
+  return page_names_;
+}
+
+const std::vector<std::string>& pftool::State::param_names(const std::string& page) const {
+  auto PAGE{pflib::upper_cp(page)};
+  auto param_list_it = param_names_.find(PAGE);
+  if (param_list_it == param_names_.end()) {
+    PFEXCEPTION_RAISE("BadPage", "Page name " + page + " not a known page.");
+  }
+  return param_list_it->second;
+}
 
 /// initial definition of the menu state
 pftool::State pftool::state{};

--- a/app/tool/pftool.h
+++ b/app/tool/pftool.h
@@ -34,11 +34,26 @@ static const int DAQ_FORMAT_ECON = 2;
 class pftool : public pflib::menu::Menu<Target*> {
  public:
   /// static variables to share across menu
-  struct State {
+  class State {
+    /// type_version of HGCROC currently being interacted with
+    std::string type_version_;
+    /// list of page names for tab completion
+    std::vector<std::string> page_names_;
+    /// list of parameter names for tab-completion
+    std::map<std::string, std::vector<std::string>> param_names_;
+   public:
+    /// default constructor which sets default type_version
+    State();
+    /// update roc type version, regenerating tab completion lists if needed
+    void update_type_version(const std::string& type_version);
+    /// get the type_version of the HGCROC currently being interacted with
+    const std::string& type_version() const;
+    /// get page names for tab completion
+    const std::vector<std::string>& page_names() const;
+    /// get the parameter names for tab completion
+    const std::vector<std::string>& param_names(const std::string& page) const;
     /// index of HGCROC currently being interacted with
     int iroc{0};
-    /// type_version of HGCROC currently being interacted with
-    std::string type_version{"sipm_rocv3b"};
     /// index of link currently being interacted with
     int ilink{0};
     /// current format mode to use

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -93,6 +93,13 @@ static void gen_scan(Target* tgt) {
   int channel = pftool::readline_int("Channel to select: ", 42);
   std::string trigger = pftool::readline("Trigger type: ", trigger_types);
 
+  /**
+   * The user can define "scan wide" parameters which are just parameters that
+   * are set for the entire scan (and then reset to their values before this command).
+   *
+   * These scan wide parameters are written into the JSON header of the output CSV file
+   * along with the other inputs to this function.
+   */
   std::map<std::string, std::map<std::string, int>> scan_wide_params;
   if (pftool::readline_bool("Are there parameters to set constant for the whole scan? ", false)) {
     do {

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -96,11 +96,16 @@ static void gen_scan(Target* tgt) {
   std::map<std::string, std::map<std::string, int>> scan_wide_params;
   if (pftool::readline_bool("Are there parameters to set constant for the whole scan? ", false)) {
     do {
-      auto page = pftool::readline("Page: ", pftool::state.page_names());
-      auto param = pftool::readline("Parameter: ", pftool::state.param_names(page));
-      auto val = pftool::readline_int("Value: ");
-      scan_wide_params[page][param] = val;
-    } while (not pftool::readline_bool("Done? ", false));
+      std::cout << "Adding a scan-wide parameter..." << std::endl;
+      try {
+        auto page = pftool::readline("  Page: ", pftool::state.page_names());
+        auto param = pftool::readline("  Parameter: ", pftool::state.param_names(page));
+        auto val = pftool::readline_int("  Value: ");
+        scan_wide_params[page][param] = val;
+      } catch (const pflib::Exception& e) {
+        pflib_log(error) << "[" << e.name() << "] : " << e.message();
+      }
+    } while (not pftool::readline_bool("done adding more scan-wide parameters? ", false));
   }
 
   std::filesystem::path parameter_points_file =
@@ -212,6 +217,7 @@ static void gen_scan(Target* tgt) {
       );
     }
     auto test_param = test_param_builder.apply();
+    pflib_log(info) << "running test parameter point " << i_param_point << " / " << param_values.size();
     tgt->daq_run(trigger, writer, nevents, pftool::state.daq_rate);
   }
 }

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -7,6 +7,8 @@
 
 ENABLE_LOGGING();
 
+#include <filesystem>
+
 #include "pflib/utility/string_format.h"
 #include "pflib/utility/json.h"
 #include "pflib/DecodeAndWrite.h"
@@ -87,7 +89,8 @@ static void gen_scan(Target* tgt) {
     "PEDESTAL", "CHARGE" //, "LED"
   };
   int nevents = pftool::readline_int("Number of events per parameter point: ", 1);
-  std::string trigger = pftool::readling("Trigger type: ", trigger_types);
+  int channel{42};
+  std::string trigger = pftool::readline("Trigger type: ", trigger_types);
   std::filesystem::path parameter_points_file =
     pftool::readline("File of parameter points: ");
   std::string output_filepath =
@@ -105,10 +108,10 @@ static void gen_scan(Target* tgt) {
       header["trigger"] = trigger;
       f << std::boolalpha
         << "# " << boost::json::serialize(header) << '\n';
-      for (const auto& [ page, paramer ] : param_names) {
+      for (const auto& [ page, parameter ] : param_names) {
         f << page << '.' << parameter << ',';
       }
-      f << pflib::packign::Sample::to_csv_header
+      f << pflib::packing::Sample::to_csv_header
         << '\n';
     },
     [&](std::ofstream& f, const pflib::packing::SingleROCEventPacket& ep) {

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -28,7 +28,7 @@ static void charge_timescan(Target* tgt) {
   int start_bx = pftool::readline_int("Starting BX? ", -1);
   int n_bx = pftool::readline_int("Number of BX? ", 3);
   std::string fname = pftool::readline_path("charge-time-scan", ".csv");
-  pflib::ROC roc{tgt->hcal().roc(pftool::state.iroc, pftool::state.type_version)};
+  pflib::ROC roc{tgt->hcal().roc(pftool::state.iroc, pftool::state.type_version())};
   auto channel_page = pflib::utility::string_format("CH_%d", channel);
   int link = (channel / 36);
   auto refvol_page = pflib::utility::string_format("REFERENCEVOLTAGE_%d", link);
@@ -120,7 +120,9 @@ static void gen_scan(Target* tgt) {
         if (row.size() != param_names.size()) {
           PFEXCEPTION_RAISE("BadRow",
               "A row in "+std::string(parameter_points_file)
-              +" does not contain the same number of cells as the header.");
+              +" contains "+std::to_string(row.size())
+              +" cells which is not "+std::to_string(param_names.size())
+              +" the number of parameters defined in the header.");
         }
         param_values.push_back(row);
       },

--- a/include/pflib/Compile.h
+++ b/include/pflib/Compile.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "pflib/Logging.h"
+#include "pflib/utility/str_to_int.h"
 #include "register_maps/register_maps_types.h"
 
 namespace YAML {
@@ -21,24 +22,6 @@ class Node;
 }
 
 namespace pflib {
-
-/**
- * Get an integer from the input string
- *
- * The normal stoi (and similar) tools don't support binary inputs
- * which are helpful in our case where sometimes the value is set
- * in binary but each bit has a non-base-2 scale.
- *
- * Supported prefixes:
- * - `0b` --> binary
- * - `0x` --> hexidecimal
- * - `0`  --> octal
- * - none of the above --> decimal
- *
- * @param[in] str string form of integer
- * @return integer decoded from string
- */
-int str_to_int(std::string str);
 
 /**
  * Get a copy of the input string with all caps

--- a/include/pflib/utility/load_integer_csv.h
+++ b/include/pflib/utility/load_integer_csv.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include <string>
 
 namespace pflib::utility {
@@ -9,15 +10,19 @@ namespace pflib::utility {
  * Load an integer CSV file, doing some Action on each row
  *
  * This function skips blank lines and comment lines that start with the `#` character.
- * Header rows are *not* skipped, so it is suggested to write the header row with a
- * leading `#` so that it is treated as a comment line.
+ *
+ * Header rows are *not* skipped.
+ * If you want to skip the header, prepend it with the `#` character so that it is treated as a comment line.
+ * You can also use the HeaderAction argument to handle the header row yourself.
  *
  * @param[in] file_name path to CSV to open and read
  * @param[in] Action function that receives the row of integer values and does something with them
+ * @param[in] HeaderAction optional function that receives a header row of strings, default nothing
  *
  * @throws Exception if no file is provided or file cannot be opened
  */
 void load_integer_csv(const std::string& file_name,
-                      const std::function<void(const std::vector<int>&)>& Action);
+                      std::function<void(const std::vector<int>&)> Action,
+                      std::optional<std::function<void(const std::vector<std::string>&)>> HeaderAction = std::nullopt);
 
 }

--- a/include/pflib/utility/str_to_int.h
+++ b/include/pflib/utility/str_to_int.h
@@ -1,0 +1,29 @@
+/**
+ * @file str_to_int.h
+ * definition of str_to_int function
+ */
+#pragma once
+
+#include <string>
+
+namespace pflib::utility {
+
+/**
+ * Get an integer from the input string
+ *
+ * The normal stoi (and similar) tools don't support binary inputs
+ * which are helpful in our case where sometimes the value is set
+ * in binary but each bit has a non-base-2 scale.
+ *
+ * Supported prefixes:
+ * - `0b` --> binary
+ * - `0x` --> hexidecimal
+ * - `0`  --> octal
+ * - none of the above --> decimal
+ *
+ * @param[in] str string form of integer
+ * @return integer decoded from string
+ */
+int str_to_int(std::string str);
+
+}

--- a/src/pflib/Compile.cxx
+++ b/src/pflib/Compile.cxx
@@ -11,27 +11,6 @@
 
 namespace pflib {
 
-int str_to_int(std::string str) {
-  if (str == "0") return 0;
-  int base = 10;
-  if (str[0] == '0' and str.length() > 2) {
-    // binary or hexadecimal
-    if (str[1] == 'b' or str[1] == 'B') {
-      base = 2;
-      str = str.substr(2);
-    } else if (str[1] == 'x' or str[1] == 'X') {
-      base = 16;
-      str = str.substr(2);
-    }
-  } else if (str[0] == '0' and str.length() > 1) {
-    // octal
-    base = 8;
-    str = str.substr(1);
-  }
-
-  return std::stoi(str, nullptr, base);
-}
-
 std::string upper_cp(const std::string& str) {
   std::string STR{str};
   for (auto& c : STR) c = toupper(c);
@@ -315,7 +294,7 @@ void Compiler::extract(
                                              param.first.as<std::string>());
         }
         std::string param_name = upper_cp(param.first.as<std::string>());
-        settings[page][param_name] = str_to_int(sval);
+        settings[page][param_name] = utility::str_to_int(sval);
       }
     }
   }

--- a/src/pflib/lpgbt/lpGBT_Utility.cxx
+++ b/src/pflib/lpgbt/lpGBT_Utility.cxx
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "pflib/Compile.h"
+#include "pflib/utility/str_to_int.h"
 #include "pflib/lpgbt/lpGBT_Registers.h"
 
 namespace pflib {
@@ -42,7 +42,7 @@ static CSVDecodedLines decode_file(const std::string& fname) {
         reg = str;
       else if (ifield == 1) {
         try {
-          val = str_to_int(str);
+          val = utility::str_to_int(str);
         } catch (std::exception& e) {
           char msg[100];
           snprintf(msg, 100, "Unable to decode string '%s'", str.c_str());
@@ -65,7 +65,7 @@ lpGBT::RegisterValueVector loadRegisterCSV(const std::string& filename) {
     uint16_t addr;
     if (line.first.find("0x") == 0 || line.first.find("0b") == 0 ||
         line.first.find_first_not_of("0123456789") == std::string::npos) {
-      addr = str_to_int(line.first);
+      addr = utility::str_to_int(line.first);
     } else {
       uint8_t mask, offset;
       if (!findRegister(line.first, addr, mask, offset)) {
@@ -95,7 +95,7 @@ void applylpGBTCSV(const std::string& filename, lpGBT& lpgbt) {
     uint8_t mask = 0xff, offset = 0;
     if (line.first.find("0x") == 0 || line.first.find("0b") == 0 ||
         line.first.find_first_not_of("0123456789") == std::string::npos) {
-      addr = str_to_int(line.first);
+      addr = utility::str_to_int(line.first);
     } else {
       if (!findRegister(line.first, addr, mask, offset)) {
         snprintf(mesg, 120, "Unknown register '%s'", line.first.c_str());

--- a/src/pflib/menu/Menu.cc
+++ b/src/pflib/menu/Menu.cc
@@ -8,7 +8,7 @@
 #include <filesystem>
 #include <fstream>
 
-#include "pflib/Compile.h"  // for str_to_int
+#include "pflib/utility/str_to_int.h"
 #include "pflib/Logging.h"
 
 namespace pflib::menu {
@@ -213,7 +213,7 @@ int BaseMenu::readline_int(const std::string& prompt, int aval, bool ashex) {
     sprintf(buffer, "0x%x", aval);
   else
     sprintf(buffer, "%d", aval);
-  return pflib::str_to_int(BaseMenu::readline(prompt, buffer));
+  return pflib::utility::str_to_int(BaseMenu::readline(prompt, buffer));
 }
 
 bool BaseMenu::readline_bool(const std::string& prompt, bool aval) {

--- a/src/pflib/utility/load_integer_csv.cxx
+++ b/src/pflib/utility/load_integer_csv.cxx
@@ -3,57 +3,62 @@
 #include <fstream>
 #include <sstream>
 #include <vector>
+#include <optional>
 
+#include "pflib/utility/str_to_int.h"
 #include "pflib/Exception.h"
 
 namespace pflib::utility {
 
 /**
- * Modern RAII-styled CSV extractor taken from
- * https://stackoverflow.com/a/1120224/17617632
- * this allows us to **discard white space within the cells**
- * making the CSV more human readable.
+ * get next row from the input stream
+ *
+ * @tparam CellType type held within cell
+ * @param[in] ss input stream to read from
+ * @param[in] conversion function to convert the cell string into desired type
+ * @return optional vector containing cells
  */
-static std::vector<int> getNextLineAndExtractValues(std::istream& ss) {
-  std::vector<int> result;
-
-  std::string line, cell;
+template <typename CellType>
+static std::optional<std::vector<CellType>> get_next_row(
+    std::istream& ss,
+    std::function<CellType(std::string)> conversion
+) {
+  std::string line;
   std::getline(ss, line);
 
+  /**
+   * if the line we read is empty or starts with `#`,
+   * then return std::nullopt to signal that there wasn't
+   * a row
+   */
   if (line.empty() or line[0] == '#') {
-    // empty line or comment, return empty container
-    return result;
+    // empty line or comment, return nullopt
+    return std::nullopt;
   }
 
+  /**
+   * when the line is not empty or a comment,
+   * fill the vector with cells separated by `,`.
+   */
+  std::vector<CellType> result;
+  std::string cell;
   std::stringstream line_stream(line);
   while (std::getline(line_stream, cell, ',')) {
-    /**
-     * std stoi has a auto-detect base feature
-     * https://en.cppreference.com/w/cpp/string/basic_string/stol
-     * which we can enable by setting the pre-defined base to 0
-     * (the third parameter) - this auto-detect base feature
-     * can handle hexidecial (prefix == 0x or 0X), octal (prefix == 0),
-     * and decimal (no prefix).
-     *
-     * The second parameter is an address to put the number of characters
-     * processed, which I disregard at this time.
-     *
-     * Do we allow empty cells?
-     */
-    result.push_back(cell.empty() ? 0 : std::stoi(cell, nullptr, 0));
+    result.push_back(conversion(cell));
   }
+
   // checks for a trailing comma with no data after it
   if (!line_stream and cell.empty()) {
-    // trailing comma, put in one more 0
-    result.push_back(0);
+    // trailing comma, put in one more empty cell
+    result.push_back(conversion(cell));
   }
 
   return result;
 }
 
-void load_integer_csv(
-    const std::string& file_name,
-    const std::function<void(const std::vector<int>&)>& Action) {
+void load_integer_csv(const std::string& file_name,
+                      std::function<void(const std::vector<int>&)> Action,
+                      std::optional<std::function<void(const std::vector<std::string>&)>> HeaderAction) {
   if (file_name.empty()) {
     PFEXCEPTION_RAISE("Filename", "No file provided to load CSV function.");
   }
@@ -62,11 +67,39 @@ void load_integer_csv(
     PFEXCEPTION_RAISE("File",
                       "Unable to open " + file_name + " in load CSV function.");
   }
+
+  bool handled_header{false};
   while (f) {
-    auto cells = getNextLineAndExtractValues(f);
-    // skip comments and blank lines
-    if (cells.empty()) continue;
-    Action(cells);
+    /**
+     * If the user provides a HeaderAction and we have not seen a header yet,
+     * then get the next line and apply the HeaderAction.
+     */
+    if (HeaderAction and not handled_header) {
+      auto cells = get_next_row<std::string>(f, [](std::string s) { return s; });
+      if (cells) {
+        HeaderAction.value()(cells.value());
+        handled_header = true;
+      }
+    } else {
+      /**
+       * If the user did not provide a HeaderAction or we already handled
+       * the header, get the next line and apply the user's action if
+       * the line is not a comment or empty.
+       */
+      auto cells = get_next_row<int>(
+          f,
+          [](std::string s) {
+            if (s.empty()) {
+              return 0;
+            } else {
+              return str_to_int(s);
+            }
+          }
+        );
+      if (cells) {
+        Action(cells.value());
+      }
+    }
   }
 }
 

--- a/src/pflib/utility/str_to_int.cxx
+++ b/src/pflib/utility/str_to_int.cxx
@@ -1,0 +1,26 @@
+#include "pflib/utility/str_to_int.h"
+
+namespace pflib::utility {
+
+int str_to_int(std::string str) {
+  if (str == "0") return 0;
+  int base = 10;
+  if (str[0] == '0' and str.length() > 2) {
+    // binary or hexadecimal
+    if (str[1] == 'b' or str[1] == 'B') {
+      base = 2;
+      str = str.substr(2);
+    } else if (str[1] == 'x' or str[1] == 'X') {
+      base = 16;
+      str = str.substr(2);
+    }
+  } else if (str[0] == '0' and str.length() > 1) {
+    // octal
+    base = 8;
+    str = str.substr(1);
+  }
+
+  return std::stoi(str, nullptr, base);
+}
+
+}

--- a/test/utility.cxx
+++ b/test/utility.cxx
@@ -54,6 +54,48 @@ BOOST_AUTO_TEST_CASE(missing_cells) {
   });
 }
 
+BOOST_AUTO_TEST_CASE(parse_header) {
+  TempCSV t("header, row,uncommented\n1,2,3\n4,5,6");
+  int val = 0;
+  pflib::utility::load_integer_csv(
+      t.file_path_,
+      [&val](const std::vector<int>& row) {
+        BOOST_CHECK(row.size() == 3);
+        for (const int& cell : row) {
+          val++;
+          BOOST_CHECK(cell == val);
+        } 
+      },
+      [](const std::vector<std::string>& row) {
+        BOOST_CHECK(row.size() == 3);
+        BOOST_CHECK(row[0] == "header");
+        BOOST_CHECK(row[1] == " row");
+        BOOST_CHECK(row[2] == "uncommented");
+      }
+  );
+}
+
+BOOST_AUTO_TEST_CASE(multiline_header) {
+  TempCSV t("# some extra comment\nheader, row,uncommented\n1,2,3\n4,5,6");
+  int val = 0;
+  pflib::utility::load_integer_csv(
+      t.file_path_,
+      [&val](const std::vector<int>& row) {
+        BOOST_CHECK(row.size() == 3);
+        for (const int& cell : row) {
+          val++;
+          BOOST_CHECK(cell == val);
+        } 
+      },
+      [](const std::vector<std::string>& row) {
+        BOOST_CHECK(row.size() == 3);
+        BOOST_CHECK(row[0] == "header");
+        BOOST_CHECK(row[1] == " row");
+        BOOST_CHECK(row[2] == "uncommented");
+      }
+  );
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(crc);

--- a/test/utility.cxx
+++ b/test/utility.cxx
@@ -96,6 +96,31 @@ BOOST_AUTO_TEST_CASE(multiline_header) {
   );
 }
 
+BOOST_AUTO_TEST_CASE(storage_params) {
+  TempCSV t("page.param1,page.param2\n1,20\n3,40\n");
+  std::vector<std::string> param_names;
+  std::vector<std::vector<int>> param_vals;
+  pflib::utility::load_integer_csv(
+      t.file_path_,
+      [&param_vals](const std::vector<int>& row) {
+        param_vals.push_back(row);
+      },
+      [&param_names](const std::vector<std::string>& row) {
+        param_names = row;
+      }
+  );
+  BOOST_CHECK_EQUAL(param_names.size(), 2);
+  BOOST_CHECK_EQUAL(param_names[0], "page.param1");
+  BOOST_CHECK_EQUAL(param_names[1], "page.param2");
+  BOOST_CHECK_EQUAL(param_vals.size(), 2);
+  BOOST_CHECK_EQUAL(param_vals[0].size(), 2);
+  BOOST_CHECK_EQUAL(param_vals[0][0], 1);
+  BOOST_CHECK_EQUAL(param_vals[0][1], 20);
+  BOOST_CHECK_EQUAL(param_vals[1].size(), 2);
+  BOOST_CHECK_EQUAL(param_vals[1][0], 3);
+  BOOST_CHECK_EQUAL(param_vals[1][1], 40);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE(crc);


### PR DESCRIPTION
Add a tasks command that allows users to scan parameters read in from an input CSV file while saving data from a specific channel to an output CSV file.

The input "parameter points" file is just a CSV where the header is used to define the parameters that will be set and the rows are the values of those parameters.

For example, the CSV
```csv
page.param1,page.param2
1,2
3,4
```

would produce two runs with this command where the parameter settings are

1. page.param1 = 1 and page.param2 = 2
2. page.param1 = 3 and page.param2 = 4
