### PR TITLE
add callbacks to consumer for start and end of run

### DIFF
--- a/include/pflib/Target.h
+++ b/include/pflib/Target.h
@@ -30,6 +30,8 @@ class Target {
    */
   class DAQRunConsumer {
    public:
+    virtual void start_run() {}
+    virtual void end_run() {}
     virtual void consume(std::vector<uint32_t>& event) = 0;
     virtual ~DAQRunConsumer() = default;
   };

--- a/src/pflib/Target.cxx
+++ b/src/pflib/Target.cxx
@@ -30,6 +30,8 @@ void Target::daq_run(
   }
   auto trigger{cmds.at(cmd)};
 
+  consumer.start_run();
+
   timeval tv0, tvi;
   gettimeofday(&tv0, 0);
   for (int ievt = 0; ievt < nevents; ievt++) {
@@ -65,6 +67,8 @@ void Target::daq_run(
       consumer.consume(event);
     }
   }
+
+  consumer.end_run();
 }
 
 }  // namespace pflib


### PR DESCRIPTION
These callbacks are helpful for consumers that will consume multiple runs. For example, in parameter scans, we often want to test each parameter with a run over many events to better characterize the chip response. With these callbacks, the consumer of these parameter scan runs could collect the samples and then only write out the median or mean for example instead of writing out all of the samples.

An example I've mocked up (and **not tested**) is on https://github.com/LDMX-Software/pflib/tree/decode-and-write-run-summary where I store a table of all the channel samples and then allow the user to define a function which writes the row at the end of each run instead of each event given the output file and the table of samples.