### PR TITLE
decode trigger links

### DIFF
--- a/app/pfdecoder.cxx
+++ b/app/pfdecoder.cxx
@@ -24,6 +24,7 @@ static void usage() {
                "  -l,--log     : logging level to printout (-1: trace up to 4: "
                "fatal)\n"
                "  --headers    : print header words and decoded value to term\n"
+               "  --trigger    : write out trigger links to term\n"
             << std::endl;
 }
 
@@ -37,6 +38,7 @@ int main(int argc, char* argv[]) {
 
   auto the_log_{pflib::logging::get("pfdecoder")};
 
+  bool trigger{false};
   bool headers{false};
   int nevents{-1};
   std::string in_file, out_file;
@@ -91,6 +93,8 @@ int main(int argc, char* argv[]) {
         }
       } else if (arg == "--headers") {
         headers = true;
+      } else if (arg == "--trigger") {
+        trigger = true;
       } else {
         pflib_log(fatal) << "Unrecognized option " << arg;
         return 1;
@@ -152,6 +156,20 @@ int main(int argc, char* argv[]) {
                     << " Orbit = " << daq_link.orbit << std::endl;
         }
       }
+
+      if (trigger) {
+        for (std::size_t i_link{0}; i_link < 4; i_link++) {
+          const auto& trig_link{ep.trigger_links[i_link]};
+          std::cout << "Link " << i_link+2 << " : TC" << trig_link.i_link << std::endl;
+          std::cout << " " << pflib::packing::hex(trig_link.data_words[1]) << std::endl;
+          for (std::size_t i_sum{0}; i_sum < 4; i_sum++) {
+            std::cout << "  Sum " << i_sum
+              << " = " << static_cast<int>(trig_link.compressed_sum(i_sum)) << " (compressed)" 
+              << " = " << trig_link.linearized_sum(i_sum) << " (linearized)" << std::endl;
+          }
+        }
+      }
+
       ep.to_csv(o);
       count++;
       if (nevents > 0 and count >= nevents) {

--- a/app/pfdecoder.cxx
+++ b/app/pfdecoder.cxx
@@ -159,13 +159,9 @@ int main(int argc, char* argv[]) {
 
       if (trigger) {
         for (std::size_t i_link{0}; i_link < 4; i_link++) {
-          const auto& trig_link{ep.trigger_links[i_link]};
-          std::cout << "Link " << i_link+2 << " : TC" << trig_link.i_link << std::endl;
-          std::cout << " " << pflib::packing::hex(trig_link.data_words[1]) << std::endl;
           for (std::size_t i_sum{0}; i_sum < 4; i_sum++) {
-            std::cout << "  Sum " << i_sum
-              << " = " << static_cast<int>(trig_link.compressed_sum(i_sum)) << " (compressed)" 
-              << " = " << trig_link.linearized_sum(i_sum) << " (linearized)" << std::endl;
+            std::cout << "TC" << i_link << "_" << i_sum
+              << " = " << ep.trigsum(i_link, i_sum) << std::endl;
           }
         }
       }

--- a/include/pflib/packing/SingleROCEventPacket.h
+++ b/include/pflib/packing/SingleROCEventPacket.h
@@ -61,6 +61,21 @@ class SingleROCEventPacket {
    * the channel index within the link [0,35].
    */
   Sample channel(int ch) const;
+
+  /**
+   * Get a trigger cell sum
+   *
+   * We do not have a unified ID number for trigger cells
+   * defined at the moment, so you need to specify both
+   * which trigger link it comes from and the index of the
+   * sum within that trigger link.
+   *
+   * @param[in] i_link trigger link 0-3
+   * @param[in] i_sum index of sum within the link 0-3
+   * @param[in] i_bx index of BX relative to in-time sample,
+   * default is 0 (the in-time sample)
+   */
+  uint32_t trigsum(int i_link, int i_sum, int i_bx = 0) const;
   /// default constructor that does nothing
   SingleROCEventPacket() = default;
 };

--- a/include/pflib/packing/TriggerLinkFrame.h
+++ b/include/pflib/packing/TriggerLinkFrame.h
@@ -102,7 +102,11 @@ struct TriggerLinkFrame {
    * view a subslice of a larger std::vector.
    */
   TriggerLinkFrame(std::span<uint32_t> data);
+
+  /// default constructor which does nothing
   TriggerLinkFrame() = default;
+
+  /// handle to logging for decoding warnings
   mutable logging::logger the_log_{logging::get("decoding")};
 };
 

--- a/include/pflib/packing/TriggerLinkFrame.h
+++ b/include/pflib/packing/TriggerLinkFrame.h
@@ -8,36 +8,36 @@
 namespace pflib::packing {
 
 /**
- * Convert a compressed trigger sum into its linearized equivalent
- *
- * The chip lossy compresses its trigger sums into seven bits
- * and this function decompresses the sum into our best estimate
- * of what the on-chip trigger sum was.
- *
- * @note This function undoes the wacky compression algorithm, but
- * the scale of the linearized sum is not quite correct.
- * If SelTC4 = 1 on the chip (sums of 4 channels), then this result
- * needs to be multiplied by 2 (or left-bit-shift by one).
- * If SelTC4 = 0 on the chip (sums of 9 channels), then this result
- * needs to be multiplied by 8 (or left-bit-shift by three)
- *
- * If SelTC4 stores the setting on the chip when the data was collected,
- * ```cpp
- * uint32_t ts = compressed_to_linearized(cs) << (SelTC4 ? 1 : 3);
- * ```
- *
- * @param[in] cs compressed sum to unpack
- * @return unpacked linearized sum
- */
-uint32_t compressed_to_linearized(uint8_t cs);
-
-/**
  * Without a trigger link set up, the decoding cannot be fuctionally tested.
  *
  * This class is merely a skeleton of how unpacking could be done for these
  * trigger link frames.
  */
 struct TriggerLinkFrame {
+  /**
+   * Convert a compressed trigger sum into its linearized equivalent
+   *
+   * The chip lossy compresses its trigger sums into seven bits
+   * and this function decompresses the sum into our best estimate
+   * of what the on-chip trigger sum was.
+   *
+   * @note This function undoes the wacky compression algorithm, but
+   * the scale of the linearized sum is not quite correct.
+   * If SelTC4 = 1 on the chip (sums of 4 channels), then this result
+   * needs to be multiplied by 2 (or left-bit-shift by one).
+   * If SelTC4 = 0 on the chip (sums of 9 channels), then this result
+   * needs to be multiplied by 8 (or left-bit-shift by three)
+   *
+   * If SelTC4 stores the setting on the chip when the data was collected,
+   * ```cpp
+   * uint32_t ts = compressed_to_linearized(cs) << (SelTC4 ? 1 : 3);
+   * ```
+   *
+   * @param[in] cs compressed sum to unpack
+   * @return unpacked linearized sum
+   */
+  static uint32_t compressed_to_linearized(uint8_t cs);
+
   /// index of data words containg sample of interest
   static const int i_soi_ = 1;
 

--- a/include/pflib/packing/TriggerLinkFrame.h
+++ b/include/pflib/packing/TriggerLinkFrame.h
@@ -28,10 +28,13 @@ struct TriggerLinkFrame {
    * If SelTC4 = 0 on the chip (sums of 9 channels), then this result
    * needs to be multiplied by 8 (or left-bit-shift by three)
    *
-   * If SelTC4 stores the setting on the chip when the data was collected,
+   * If `SelTC4` stores the setting on the chip when the data was collected
+   * and `lin_val` is the value returned by this function, then
    * ```cpp
-   * uint32_t ts = compressed_to_linearized(cs) << (SelTC4 ? 1 : 3);
+   * lin_val << (SelTC4 ? 1 : 3)
    * ```
+   * is the integer value pertaining to the correct scale of the sums as
+   * determined on the chip.
    *
    * @param[in] cs compressed sum to unpack
    * @return unpacked linearized sum

--- a/include/pflib/packing/TriggerLinkFrame.h
+++ b/include/pflib/packing/TriggerLinkFrame.h
@@ -3,7 +3,33 @@
 #include <cstdint>
 #include <span>
 
+#include "pflib/Logging.h"
+
 namespace pflib::packing {
+
+/**
+ * Convert a compressed trigger sum into its linearized equivalent
+ *
+ * The chip lossy compresses its trigger sums into seven bits
+ * and this function decompresses the sum into our best estimate
+ * of what the on-chip trigger sum was.
+ *
+ * @note This function undoes the wacky compression algorithm, but
+ * the scale of the linearized sum is not quite correct.
+ * If SelTC4 = 1 on the chip (sums of 4 channels), then this result
+ * needs to be multiplied by 2 (or left-bit-shift by one).
+ * If SelTC4 = 0 on the chip (sums of 9 channels), then this result
+ * needs to be multiplied by 8 (or left-bit-shift by three)
+ *
+ * If SelTC4 stores the setting on the chip when the data was collected,
+ * ```cpp
+ * uint32_t ts = compressed_to_linearized(cs) << (SelTC4 ? 1 : 3);
+ * ```
+ *
+ * @param[in] cs compressed sum to unpack
+ * @return unpacked linearized sum
+ */
+uint32_t compressed_to_linearized(uint8_t cs);
 
 /**
  * Without a trigger link set up, the decoding cannot be fuctionally tested.
@@ -12,8 +38,55 @@ namespace pflib::packing {
  * trigger link frames.
  */
 struct TriggerLinkFrame {
+  /// index of data words containg sample of interest
+  static const int i_soi_ = 1;
+
+  /// trigger link identification number
   int i_link;
+
+  /**
+   * Trigger words including one pre-sample and 2 following samples
+   *
+   * A trigger word contains 4 7-bit trigger sums and a 4-bit leading
+   * header to help check for corruption and link alignment.
+   */
   std::array<uint32_t, 4> data_words;
+
+  /**
+   * Checks on data format
+   *
+   * Index | Description
+   * ------|-------------
+   *  0    | leading four-bits of sw header is wrong
+   *  1    | leading four-bits of 0'th data word is wrong
+   *  2    | leading four-bits of 1st data word is wrong
+   *  3    | leading four-bits of 2nd data word is wrong
+   *  4    | leading four-bits of 3rd data word is wrong
+   */
+  std::array<bool, 5> corruption;
+
+  /**
+   * Get a specific compressed trigger sum from the data words
+   *
+   * @param[in] i_sum sum index 0, 1, 2, or 3
+   * @param[in] i_bx bunch index relative to i_soi_ -1, 0, 1, or 2
+   * @return compressed trigger sum as determined by the chip
+   */
+  uint8_t compressed_sum(int i_sum, int i_bx = 0) const;
+
+  /**
+   * Get a specific linearized trigger sum from the data words
+   *
+   * @see compressed_sum for how accessing a specific sum within
+   * a trigger word is implemented.
+   * @see compressed_to_linearized for how this compressed seven-bit
+   * sum is unpacked into the linearized form.
+   *
+   * @param[in] i_sum sum index 0, 1, 2, or 3
+   * @param[in] i_bx bunch index relative to i_soi_ -1, 0, 1, or 2
+   * @return linearized trigger sum as determined by the chip
+   */
+  uint32_t linearized_sum(int i_sum, int i_bx = 0) const;
 
   /**
    * Parse into this link frame from a std::span over 32-bit words
@@ -30,6 +103,7 @@ struct TriggerLinkFrame {
    */
   TriggerLinkFrame(std::span<uint32_t> data);
   TriggerLinkFrame() = default;
+  mutable logging::logger the_log_{logging::get("decoding")};
 };
 
 }  // namespace pflib::packing

--- a/src/pflib/packing/SingleROCEventPacket.cxx
+++ b/src/pflib/packing/SingleROCEventPacket.cxx
@@ -31,10 +31,7 @@ void SingleROCEventPacket::from(std::span<uint32_t> data) {
     if (i_link < 2) {
       daq_links[i_link].from(data.subspan(link_start_offset, link_len));
     } else {
-      pflib_log(trace) << "trigger link - skip";
-      /*
       trigger_links[i_link-2].from(data.subspan(link_start_offset, link_len));
-      */
     }
     link_start_offset += link_len;
   }

--- a/src/pflib/packing/SingleROCEventPacket.cxx
+++ b/src/pflib/packing/SingleROCEventPacket.cxx
@@ -5,6 +5,7 @@
 
 #include "pflib/packing/Hex.h"
 #include "pflib/packing/Mask.h"
+#include "pflib/Exception.h"
 
 namespace pflib::packing {
 
@@ -118,6 +119,21 @@ Sample SingleROCEventPacket::channel(int ch) const {
   int i_link = (ch / 36);
   int i_ch_in_link = (ch % 36);
   return daq_links[i_link].channels[i_ch_in_link];
+}
+
+uint32_t SingleROCEventPacket::trigsum(int i_link, int i_sum, int i_bx) const {
+  if (i_link < 0 or i_link > 3) {
+    PFEXCEPTION_RAISE("OutOfRange",
+        "Trigger link "+std::to_string(i_link)+" is not in the range [0,3].");
+  }
+  /**
+   * We return the linearized sum since that is what most people want.
+   * @see TriggerLinkFrame::compressed_to_linearized for how this value
+   * is determined and how you should interpret it. TLDR: the value is
+   * linearized but is off by some scale factor that depends on the SelTC4
+   * parameter on the chip.
+   */
+  return trigger_links[i_link].linearized_sum(i_sum, i_bx);
 }
 
 }  // namespace pflib::packing

--- a/src/pflib/packing/TriggerLinkFrame.cxx
+++ b/src/pflib/packing/TriggerLinkFrame.cxx
@@ -3,8 +3,21 @@
 #include <iostream>
 
 #include "pflib/packing/Mask.h"
+#include "pflib/Exception.h"
 
 namespace pflib::packing {
+
+uint32_t compressed_to_linearized(uint8_t cs) {
+  auto pos = (cs >> 3) & 0xf;
+  if (pos < 1) {
+    // no position stored (i.e. compressed value is < 8)
+    // linearized sum is sum stored as compressed
+    return cs;
+  }
+  return (
+    ((1 << 3) + (cs & 0b111)) << (pos + 2 - 3)
+  );
+}
 
 void TriggerLinkFrame::from(std::span<uint32_t> data) {
   if (data.size() != 5) {
@@ -13,15 +26,35 @@ void TriggerLinkFrame::from(std::span<uint32_t> data) {
         std::to_string(data.size()));
   }
 
-  if ((data[0] >> 28) != 0b0011) {
-    // bad!
-    std::cout << "bad trigger link header" << std::endl;
+  if ((data[0] >> 28) != 0x3) {
+    pflib_log(warn) << "bad link frame header inserted by software, probably software bug";
   }
 
   i_link = (data[0] & mask<8>);
   for (std::size_t i_word{0}; i_word < 4; i_word++) {
+    auto head{data[i_word + 1] >> 28};
+    if (head != 0xa and head != 0x6) {
+      pflib_log(warn) << "bad leading-four bits inserted by chip, probably link misalignment";
+    }
     data_words[i_word] = data[i_word + 1];
   }
+}
+
+uint8_t TriggerLinkFrame::compressed_sum(int i_sum, int i_bx) const {
+  if (i_bx < -1 or i_bx > 2) {
+    PFEXCEPTION_RAISE("OutOfRange", "The provided BX index "+std::to_string(i_bx)
+        +" is outside the allow range of -1 to 2");
+  }
+  if (i_sum < 0 or i_sum > 3) {
+    PFEXCEPTION_RAISE("OutOfRange", "The provided sum index "+std::to_string(i_sum)
+        +" is outside the allow range of 0 to 3");
+  }
+  uint32_t w = data_words[i_soi_+i_bx];
+  return ((w >> (i_sum*7)) & mask<7>);
+}
+
+uint32_t TriggerLinkFrame::linearized_sum(int i_sum, int i_bx) const {
+  return compressed_to_linearized(compressed_sum(i_sum, i_bx));
 }
 
 TriggerLinkFrame::TriggerLinkFrame(std::span<uint32_t> data) { from(data); }

--- a/src/pflib/packing/TriggerLinkFrame.cxx
+++ b/src/pflib/packing/TriggerLinkFrame.cxx
@@ -7,7 +7,7 @@
 
 namespace pflib::packing {
 
-uint32_t compressed_to_linearized(uint8_t cs) {
+uint32_t TriggerLinkFrame::compressed_to_linearized(uint8_t cs) {
   auto pos = (cs >> 3) & 0xf;
   if (pos < 1) {
     // no position stored (i.e. compressed value is < 8)

--- a/src/pflib/packing/TriggerLinkFrame.cxx
+++ b/src/pflib/packing/TriggerLinkFrame.cxx
@@ -26,14 +26,16 @@ void TriggerLinkFrame::from(std::span<uint32_t> data) {
         std::to_string(data.size()));
   }
 
-  if ((data[0] >> 28) != 0x3) {
+  corruption[0] = ((data[0] >> 28) != 0x3);
+  if (corruption[0]) {
     pflib_log(warn) << "bad link frame header inserted by software, probably software bug";
   }
 
   i_link = (data[0] & mask<8>);
   for (std::size_t i_word{0}; i_word < 4; i_word++) {
     auto head{data[i_word + 1] >> 28};
-    if (head != 0xa and head != 0x6) {
+    corruption[i_word+1] = (head != 0xa and head != 0x9);
+    if (corruption[i_word+1]) {
       pflib_log(warn) << "bad leading-four bits inserted by chip, probably link misalignment";
     }
     data_words[i_word] = data[i_word + 1];

--- a/src/pflib/packing/TriggerLinkFrame.cxx
+++ b/src/pflib/packing/TriggerLinkFrame.cxx
@@ -52,7 +52,7 @@ uint8_t TriggerLinkFrame::compressed_sum(int i_sum, int i_bx) const {
         +" is outside the allow range of 0 to 3");
   }
   uint32_t w = data_words[i_soi_+i_bx];
-  return ((w >> (i_sum*7)) & mask<7>);
+  return ((w >> ((3-i_sum)*7)) & mask<7>);
 }
 
 uint32_t TriggerLinkFrame::linearized_sum(int i_sum, int i_bx) const {

--- a/test/decoding.cxx
+++ b/test/decoding.cxx
@@ -173,21 +173,21 @@ BOOST_AUTO_TEST_SUITE(trigger)
 BOOST_AUTO_TEST_CASE(example_decompression) {
   uint8_t compressed = 0b0100111;
   uint32_t decomp = 0b1111000;
-  BOOST_CHECK_EQUAL(decomp, pflib::packing::compressed_to_linearized(compressed));
+  BOOST_CHECK_EQUAL(decomp, pflib::packing::TriggerLinkFrame::compressed_to_linearized(compressed));
 }
 
 BOOST_AUTO_TEST_CASE(decompress_zero) {
-  BOOST_CHECK_EQUAL(0, pflib::packing::compressed_to_linearized(0));
+  BOOST_CHECK_EQUAL(0, pflib::packing::TriggerLinkFrame::compressed_to_linearized(0));
 }
 
 BOOST_AUTO_TEST_CASE(decompress_small) {
-  BOOST_CHECK_EQUAL(5, pflib::packing::compressed_to_linearized(5));
+  BOOST_CHECK_EQUAL(5, pflib::packing::TriggerLinkFrame::compressed_to_linearized(5));
 }
 
 BOOST_AUTO_TEST_CASE(decompress_large) {
   uint8_t compressed = 0b1111011;
   uint32_t decomp = 0b101100000000000000;
-  BOOST_CHECK_EQUAL(decomp, pflib::packing::compressed_to_linearized(compressed));
+  BOOST_CHECK_EQUAL(decomp, pflib::packing::TriggerLinkFrame::compressed_to_linearized(compressed));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/decoding.cxx
+++ b/test/decoding.cxx
@@ -5,6 +5,7 @@
 #include "pflib/packing/DAQLinkFrame.h"
 #include "pflib/packing/Sample.h"
 #include "pflib/packing/Mask.h"
+#include "pflib/packing/TriggerLinkFrame.h"
 
 BOOST_AUTO_TEST_SUITE(decoding)
 
@@ -163,6 +164,30 @@ BOOST_AUTO_TEST_CASE(foo) {
     BOOST_CHECK(ch.adc_tm1() == 0);
     BOOST_CHECK(ch.toa() == i_ch);
   }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(trigger)
+
+BOOST_AUTO_TEST_CASE(example_decompression) {
+  uint8_t compressed = 0b0100111;
+  uint32_t decomp = 0b1111000;
+  BOOST_CHECK_EQUAL(decomp, pflib::packing::compressed_to_linearized(compressed));
+}
+
+BOOST_AUTO_TEST_CASE(decompress_zero) {
+  BOOST_CHECK_EQUAL(0, pflib::packing::compressed_to_linearized(0));
+}
+
+BOOST_AUTO_TEST_CASE(decompress_small) {
+  BOOST_CHECK_EQUAL(5, pflib::packing::compressed_to_linearized(5));
+}
+
+BOOST_AUTO_TEST_CASE(decompress_large) {
+  uint8_t compressed = 0b1111011;
+  uint32_t decomp = 0b101100000000000000;
+  BOOST_CHECK_EQUAL(decomp, pflib::packing::compressed_to_linearized(compressed));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/decoding.cxx
+++ b/test/decoding.cxx
@@ -190,6 +190,27 @@ BOOST_AUTO_TEST_CASE(decompress_large) {
   BOOST_CHECK_EQUAL(decomp, pflib::packing::TriggerLinkFrame::compressed_to_linearized(compressed));
 }
 
+BOOST_AUTO_TEST_CASE(full_frame) {
+  std::vector<uint32_t> frame = {
+    0x300000f0, // sw header
+    0xafe00000, // i_sum=0 is full at i_bx=-1
+    0xa01fc000, // i_sum=1 is full at i_bx=0
+    0xa0003f80, // i_sum=2 is full at i_bx=1
+    0xa000007f  // i_sum=3 is full at i_bx=2
+  };
+  pflib::packing::TriggerLinkFrame tlf(frame);
+  BOOST_CHECK_EQUAL(tlf.i_link, 0xf0);
+  for (int i_bx{-1}; i_bx < 3; i_bx++) {
+    for (int i_sum{0}; i_sum < 4; i_sum++) {
+      BOOST_TEST_INFO("checking compressed sum " << i_sum << " in BX " << i_bx);
+      BOOST_CHECK_EQUAL(
+        tlf.compressed_sum(i_sum, i_bx),
+        (i_sum-1 == i_bx) ? 0x7f : 0
+      );
+    }
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This resolves #152 

- unpack the multi-sample trigger words into trigger sums upon request
- add tests to make sure decoding/unpacking is operating as documented in manual
- add accessor into SingleROCEventPacket for ease of access to trigger sums
- add option to print out trigger sums in pfdecoder for basic testing
- document that the scale of the linearized trigger sums has not been applied (depends on the SelTC4 parameter of the chip)