### PR TITLE
need to apply test parameters in function scope

### DIFF
--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -95,34 +95,33 @@ static void charge_timescan(Target* tgt) {
   bool preCC = false;
   bool highrange = false;
   int calib = 0;
-  
+
+  auto test_param_builder = roc.testParameters();
   if(isLED){
     fname = pftool::readline_path("led-time-scan", ".csv");
     //Makes sure charge injections are turned off (in this ch at least)
-    auto test_param_handle = roc.testParameters()
+    test_param_builder
       .add(refvol_page, "CALIB", 0)
       .add(refvol_page, "CALIB_2V5", 0)
       .add(refvol_page, "INTCTEST", 1)
       .add(refvol_page, "CHOICE_CINJ", 0)
       .add(channel_page, "HIGHRANGE", 0)
-      .add(channel_page, "LOWRANGE", 0)
-      .apply();
-  }
-  else{
+      .add(channel_page, "LOWRANGE", 0);
+  } else{
     preCC = pftool::readline_bool("Use pre-CC charge injection? ", false);
     highrange = false;
     if (!preCC) highrange = pftool::readline_bool("Use highrange (Y) or lowrange (N)? ", false);
     calib = pftool::readline_int("Setting for calib pulse amplitude? ", highrange ? 64 : 1024);
     fname = pftool::readline_path("charge-time-scan", ".csv");
-    auto test_param_handle = roc.testParameters()
+    test_param_builder
       .add(refvol_page, "CALIB", preCC ? 0 : calib)
       .add(refvol_page, "CALIB_2V5", preCC ? calib : 0)
       .add(refvol_page, "INTCTEST", 1)
       .add(refvol_page, "CHOICE_CINJ", (highrange && !preCC) ? 1 : 0)
       .add(channel_page, "HIGHRANGE", (highrange || preCC) ? 1 : 0)
-      .add(channel_page, "LOWRANGE", preCC ? 0 : highrange ? 0 : 1)
-      .apply();
+      .add(channel_page, "LOWRANGE", preCC ? 0 : highrange ? 0 : 1);
   }
+  auto test_param_handle = test_param_builder.apply();
   int phase_strobe{0};
   int charge_to_l1a{0};
   double time{0};


### PR DESCRIPTION
If they are applied within the `if-else` blocks, the handles immediately go out of scope and the parameters are immediately unset.

On `main` running
```
 > CHARGE_TIMESCAN                                                                                                    
How many events per time point?  [1]                                                                                  
Flash LED instead of the internal calibration pulse? (Y/N)  [Y] N
Channel to pulse into?  [61]                                                                                          
Starting BX?  [-1]                                                                                                    
Number of BX?  [3]                                                                                                    
Use pre-CC charge injection?  (Y/N)  [N]                                                                              
Use highrange (Y) or lowrange (N)?  (Y/N)  [N]                                                                        
Setting for calib pulse amplitude?  [1024]                                                                            
Filename:  [../data/charge-time-scan-2025-07-08-135015.csv]  
```
[charge-time-scan-2025-07-08-135015.csv](https://github.com/user-attachments/files/21123157/charge-time-scan-2025-07-08-135015.csv)

![no-pulse](https://github.com/user-attachments/assets/277b08f6-2a2e-489a-a386-41e663aeddb2)

where you can see no pulse.

On this branch, doing the same command, we can see a pulse.

![pulse](https://github.com/user-attachments/assets/170b26f0-6f85-466a-93dd-0ecd3163ad4d)
