### PR TITLE
set_toa function for tasks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(pflib SHARED
   src/pflib/GPIO.cxx
   src/pflib/Elinks.cxx
   src/pflib/DecodeAndWrite.cxx
+  src/pflib/DecodeAndBuffer.cxx
   src/pflib/WriteToBinaryFile.cxx
   src/pflib/lpGBT.cxx
   src/pflib/lpgbt/lpGBT_ConfigTransport_I2C.cxx

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -118,7 +118,7 @@ static pflib::ROC::TestParameters set_toa(Target* tgt, pflib::ROC& roc, int chan
         ).apply();
     tgt->daq_run("CHARGE", buffer, nevents, pftool::state.daq_rate);
     std::vector<double> toa_data;
-    std::vector<pflib::packing::SingleROCEventPacket> data = buffer.read_data();
+    std::vector<pflib::packing::SingleROCEventPacket> data = buffer.read_and_flush();
     for (const pflib::packing::SingleROCEventPacket ep : data) {
       auto toa = ep.channel(channel).toa();
       if (toa > 0) {
@@ -138,7 +138,7 @@ static pflib::ROC::TestParameters set_toa(Target* tgt, pflib::ROC& roc, int chan
     }
     toa_vref += 1;
   }
-  PFEXCEPTION("NOTOA", "No TOA threshold was found for channel " + std::stoi(channel) + "!");
+  PFEXCEPTION_RAISE("NOTOA", "No TOA threshold was found for channel " + std::to_string(channel) + "!");
 }
 
 /**

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -161,7 +161,6 @@ static void charge_timescan(Target* tgt) {
   bool highrange = false;
   int calib = 0;
 
-
   auto test_param_builder = roc.testParameters();
   if(isLED){
     fname = pftool::readline_path("led-time-scan", ".csv");

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -112,15 +112,12 @@ static void set_toa(Target* tgt, pflib::ROC& roc, int channel) {
 
   tgt->setup_run(1 /* dummy - not stored */, DAQ_FORMAT_SIMPLEROC, 1 /* dummy */);
   for (int toa_vref = 100; toa_vref < 250; toa_vref++) {
-    auto test_handle = roc.testParameters().add(
-        refvol_page,
-        "TOA_VREF",
-        toa_vref
-        ).apply();
+    auto test_handle = roc.testParameters()
+      .add(refvol_page, "TOA_VREF", toa_vref)
+      .apply();
     tgt->daq_run("CHARGE", buffer, nevents, pftool::state.daq_rate);
     std::vector<double> toa_data;
-    std::vector<pflib::packing::SingleROCEventPacket> data = buffer.read_buffer();
-    for (const pflib::packing::SingleROCEventPacket ep : data) {
+    for (const pflib::packing::SingleROCEventPacket &ep : buffer.get_buffer()) {
       auto toa = ep.channel(channel).toa();
       if (toa > 0) {
         toa_data.push_back(toa);
@@ -128,11 +125,7 @@ static void set_toa(Target* tgt, pflib::ROC& roc, int channel) {
     }
     toa_eff = static_cast<double>(toa_data.size())/nevents;
     if (toa_eff == 1) {
-      roc.applyParameter(
-          refvol_page,
-          "TOA_VREF",
-          toa_vref
-          );
+      roc.applyParameter(refvol_page, "TOA_VREF", toa_vref);
       pflib_log(info) << "the TOA threshold is set to " << toa_vref;
       return;
     }

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -92,7 +92,7 @@ static pflib::ROC::TestParameters set_toa(Target* tgt, pflib::ROC& roc, int chan
   int link = (channel / 36);
   auto refvol_page = pflib::utility::string_format("REFERENCEVOLTAGE_%d", link);
   auto channel_page = pflib::utility::string_format("CH_%d", channel);
-  int nevents = 50;
+  int nevents = 30;
   double toa_eff{2};
   // in the calibration documentation, it is suggested to send a "small" charge injection.
   // Here I used 200 but there is maybe a better value.
@@ -107,7 +107,7 @@ static pflib::ROC::TestParameters set_toa(Target* tgt, pflib::ROC& roc, int chan
   pflib_log(info) << "finding the TOA threshold!";
   // This class doesn't write to csv. When we just would like to
   // use the data for setting params.
-  pflib::DecodeAndWriteToBuffer buffer;
+  pflib::DecodeAndBuffer buffer;
 
   tgt->setup_run(1 /* dummy - not stored */, DAQ_FORMAT_SIMPLEROC, 1 /* dummy */);
   for (int toa_vref = 100; toa_vref < 250; toa_vref++) {
@@ -138,7 +138,7 @@ static pflib::ROC::TestParameters set_toa(Target* tgt, pflib::ROC& roc, int chan
     }
     toa_vref += 1;
   }
-  throw std::logic_error("No TOA threshold was found!");
+  PFEXCEPTION("NOTOA", "No TOA threshold was found for channel " + std::stoi(channel) + "!");
 }
 
 /**

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -108,7 +108,7 @@ static void set_toa(Target* tgt, pflib::ROC& roc, int channel) {
   pflib_log(info) << "finding the TOA threshold!";
   // This class doesn't write to csv. When we just would like to
   // use the data for setting params.
-  pflib::DecodeAndBufferToRead buffer(nevents);
+  pflib::DecodeAndBuffer buffer(nevents);
 
   tgt->setup_run(1 /* dummy - not stored */, DAQ_FORMAT_SIMPLEROC, 1 /* dummy */);
   for (int toa_vref = 100; toa_vref < 250; toa_vref++) {

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -88,7 +88,7 @@ load_parameter_points(const std::string& filepath) {
  * The calib value which defines a small pulse. 
  *
  */
-static pflib::ROC::TestParameters set_toa(Target* tgt, pflib::ROC& roc, int channel) {
+static void set_toa(Target* tgt, pflib::ROC& roc, int channel) {
   int link = (channel / 36);
   auto refvol_page = pflib::utility::string_format("REFERENCEVOLTAGE_%d", link);
   auto channel_page = pflib::utility::string_format("CH_%d", channel);
@@ -127,14 +127,13 @@ static pflib::ROC::TestParameters set_toa(Target* tgt, pflib::ROC& roc, int chan
     }
     toa_eff = static_cast<double>(toa_data.size())/nevents;
     if (toa_eff == 1) {
-      auto toa_builder = roc.testParameters();
-      toa_builder.add(
+      roc.applyParameter(
           refvol_page,
           "TOA_VREF",
           toa_vref
           );
       pflib_log(info) << "the TOA threshold is set to " << toa_vref;
-      return toa_builder.apply();
+      return;
     }
     toa_vref += 1;
   }

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -13,6 +13,7 @@ ENABLE_LOGGING();
 #include "pflib/utility/load_integer_csv.h"
 #include "pflib/utility/json.h"
 #include "pflib/DecodeAndWrite.h"
+#include "pflib/DecodeAndBuffer.h"
 
 /**
  * load a CSV of parameter points into member
@@ -107,7 +108,7 @@ static void set_toa(Target* tgt, pflib::ROC& roc, int channel) {
   pflib_log(info) << "finding the TOA threshold!";
   // This class doesn't write to csv. When we just would like to
   // use the data for setting params.
-  pflib::DecodeAndBuffer buffer;
+  pflib::DecodeAndBufferToRead buffer(nevents);
 
   tgt->setup_run(1 /* dummy - not stored */, DAQ_FORMAT_SIMPLEROC, 1 /* dummy */);
   for (int toa_vref = 100; toa_vref < 250; toa_vref++) {
@@ -118,7 +119,7 @@ static void set_toa(Target* tgt, pflib::ROC& roc, int channel) {
         ).apply();
     tgt->daq_run("CHARGE", buffer, nevents, pftool::state.daq_rate);
     std::vector<double> toa_data;
-    std::vector<pflib::packing::SingleROCEventPacket> data = buffer.read_and_flush();
+    std::vector<pflib::packing::SingleROCEventPacket> data = buffer.read_buffer();
     for (const pflib::packing::SingleROCEventPacket ep : data) {
       auto toa = ep.channel(channel).toa();
       if (toa > 0) {

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -162,8 +162,6 @@ static void charge_timescan(Target* tgt) {
   bool highrange = false;
   int calib = 0;
 
-  set_toa(tgt, roc, channel);
-
   auto test_param_builder = roc.testParameters();
   if(isLED){
     fname = pftool::readline_path("led-time-scan", ".csv");

--- a/app/tool/tasks.cxx
+++ b/app/tool/tasks.cxx
@@ -162,6 +162,8 @@ static void charge_timescan(Target* tgt) {
   bool highrange = false;
   int calib = 0;
 
+  set_toa(tgt, roc, channel);
+
   auto test_param_builder = roc.testParameters();
   if(isLED){
     fname = pftool::readline_path("led-time-scan", ".csv");

--- a/include/pflib/DecodeAndBuffer.h
+++ b/include/pflib/DecodeAndBuffer.h
@@ -7,6 +7,7 @@
 #include "pflib/packing/SingleROCEventPacket.h"
 #include "pflib/Logging.h"
 #include "pflib/Target.h"
+#include "pflib/DecodeAndWrite.h"
 
 namespace pflib {
 
@@ -18,17 +19,20 @@ namespace pflib {
  * of every event.
  *
  */
-class DecodeAndBuffer : public Target::DAQRunConsumer {
+class DecodeAndBuffer : DecodeAndWrite {
   public:
+    DecodeAndBuffer(int nevents);
     virtual ~DecodeAndBuffer() = default;
     /// get buffer
     std::vector<pflib::packing::SingleROCEventPacket> get_buffer();
     /// Set the buffer size
     void set_buffer_size(int nevents);
     /// Save to buffer
-    virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) = 0;
+    virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) override;
     /// Consumer for events
     virtual void consume(std::vector<uint32_t>& event) final;
+    /// Read out buffer
+    std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
     /// Check that the buffer was read and flushed since last run
     virtual void start_run() override;
   private:
@@ -36,26 +40,8 @@ class DecodeAndBuffer : public Target::DAQRunConsumer {
     pflib::packing::SingleROCEventPacket ep_;
     /// Buffer for event packets
     std::vector<pflib::packing::SingleROCEventPacket> ep_buffer_;
-    /// Capacity of the buffer
-    int buffer_size_;
     /// logging for warning messages
     mutable ::pflib::logging::logger the_log_;
-};
-
-
-/**
- * Subclass for implementation
- * 
- */
-class DecodeAndBufferToRead : public DecodeAndBuffer {
-  public:
-    DecodeAndBufferToRead(int nevents);
-    virtual ~DecodeAndBufferToRead() = default;
-    virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) override {
-      DecodeAndBuffer::write_event(ep);
-    };
-    /// Read out buffer
-    std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
 };
 
 }

--- a/include/pflib/DecodeAndBuffer.h
+++ b/include/pflib/DecodeAndBuffer.h
@@ -13,33 +13,33 @@ namespace pflib {
 
 /**
  * Consume an event packet, decode it, and save to buffer.
- * The constructor takes an argument of the size of the buffer.
+ * The constructor takes an argument of the size of the buffer which should
+ * be the number of events being collected in the run(s) where this buffer is used.
  *
- * The buffer can be read out with read_buffer(). The buffer is cleared upon the start
- * of every event.
+ * The buffer can be read out with get_buffer().
+ * The buffer is cleared upon the start of every run.
  *
+ * Avoid copying this potentially large buffer around by using constant references.
+ * ```cpp
+ * // after daq_run has filled the DecodeAndBuffer object 'buffer'
+ * const auto& events{buffer.get_buffer()};
+ * ```
  */
 class DecodeAndBuffer : public DecodeAndWrite {
   public:
     DecodeAndBuffer(int nevents);
     virtual ~DecodeAndBuffer() = default;
     /// get buffer
-    std::vector<pflib::packing::SingleROCEventPacket> get_buffer();
+    const std::vector<pflib::packing::SingleROCEventPacket>& get_buffer() const;
     /// Set the buffer size
     void set_buffer_size(int nevents);
     /// Save to buffer
     virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) override;
-    /// Read out buffer
-    std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
     /// Check that the buffer was read and flushed since last run
     virtual void start_run() override;
   private:
-    /// event packet for decoding
-    pflib::packing::SingleROCEventPacket ep_;
     /// Buffer for event packets
     std::vector<pflib::packing::SingleROCEventPacket> ep_buffer_;
-    /// logging for warning messages
-    mutable ::pflib::logging::logger the_log_;
 };
 
 }

--- a/include/pflib/DecodeAndBuffer.h
+++ b/include/pflib/DecodeAndBuffer.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <memory>
+#include <functional>
+#include <vector>
+
+#include "pflib/packing/SingleROCEventPacket.h"
+#include "pflib/Logging.h"
+#include "pflib/Target.h"
+
+namespace pflib {
+
+/**
+ * Consume an event packet, decode it, and save to buffer.
+ * The constructor takes an argument of the size of the buffer.
+ *
+ * The buffer can be read out with read_buffer(). The buffer is cleared upon the start
+ * of every event.
+ *
+ */
+class DecodeAndBuffer : public Target::DAQRunConsumer {
+  public:
+    // Constructor for allocating the size of the buffer.
+    DecodeAndBuffer(int nevents);
+    virtual ~DecodeAndBuffer() = default;
+    /// Read out buffer
+    virtual std::vector<pflib::packing::SingleROCEventPacket> read_and_flush();
+    /// Save to buffer
+    virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) = 0;
+    /// Consumer for events
+    virtual void consume(std::vector<uint32_t>& event) final;
+    /// Check that the buffer was read and flushed since last run
+    virtual void start_run() override;
+    /// Failcheck if the buffer is getting too big
+    virtual void end_run() override;
+  private:
+    /// event packet for decoding
+    pflib::packing::SingleROCEventPacket ep_;
+    /// Buffer for event packets
+    std::vector<pflib::packing::SingleROCEventPacket> ep_buffer_;
+    /// Capacity of the buffer
+    int buffer_size_;
+    /// logging for warning messages
+    mutable ::pflib::logging::logger the_log_;
+};
+
+}

--- a/include/pflib/DecodeAndBuffer.h
+++ b/include/pflib/DecodeAndBuffer.h
@@ -20,11 +20,14 @@ namespace pflib {
  */
 class DecodeAndBuffer : public Target::DAQRunConsumer {
   public:
+    DecodeAndBuffer(int nevents);
     virtual ~DecodeAndBuffer() = default;
     /// Read out buffer
     virtual std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
     /// Save to buffer
     virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) = 0;
+    /// Read out buffer
+    virtual std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
     /// Consumer for events
     virtual void consume(std::vector<uint32_t>& event) final;
     /// Check that the buffer was read and flushed since last run
@@ -46,8 +49,6 @@ class DecodeAndBufferToRead : public DecodeAndBuffer {
     DecodeAndBufferToRead(int nevents);
     virtual ~DecodeAndBufferToRead() = default;
     virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) final;
-    /// Read out buffer
-    virtual std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
 };
 
 }

--- a/include/pflib/DecodeAndBuffer.h
+++ b/include/pflib/DecodeAndBuffer.h
@@ -20,19 +20,15 @@ namespace pflib {
  */
 class DecodeAndBuffer : public Target::DAQRunConsumer {
   public:
-    // Constructor for allocating the size of the buffer.
-    DecodeAndBuffer(int nevents);
     virtual ~DecodeAndBuffer() = default;
     /// Read out buffer
-    virtual std::vector<pflib::packing::SingleROCEventPacket> read_and_flush();
+    virtual std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
     /// Save to buffer
     virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) = 0;
     /// Consumer for events
     virtual void consume(std::vector<uint32_t>& event) final;
     /// Check that the buffer was read and flushed since last run
     virtual void start_run() override;
-    /// Failcheck if the buffer is getting too big
-    virtual void end_run() override;
   private:
     /// event packet for decoding
     pflib::packing::SingleROCEventPacket ep_;
@@ -42,6 +38,16 @@ class DecodeAndBuffer : public Target::DAQRunConsumer {
     int buffer_size_;
     /// logging for warning messages
     mutable ::pflib::logging::logger the_log_;
+};
+
+
+class DecodeAndBufferToRead : public DecodeAndBuffer {
+  public:
+    DecodeAndBufferToRead(int nevents);
+    virtual ~DecodeAndBufferToRead() = default;
+    virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) final;
+    /// Read out buffer
+    virtual std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
 };
 
 }

--- a/include/pflib/DecodeAndBuffer.h
+++ b/include/pflib/DecodeAndBuffer.h
@@ -19,7 +19,7 @@ namespace pflib {
  * of every event.
  *
  */
-class DecodeAndBuffer : DecodeAndWrite {
+class DecodeAndBuffer : public DecodeAndWrite {
   public:
     DecodeAndBuffer(int nevents);
     virtual ~DecodeAndBuffer() = default;
@@ -29,8 +29,6 @@ class DecodeAndBuffer : DecodeAndWrite {
     void set_buffer_size(int nevents);
     /// Save to buffer
     virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) override;
-    /// Consumer for events
-    virtual void consume(std::vector<uint32_t>& event) final;
     /// Read out buffer
     std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
     /// Check that the buffer was read and flushed since last run

--- a/include/pflib/DecodeAndBuffer.h
+++ b/include/pflib/DecodeAndBuffer.h
@@ -20,14 +20,13 @@ namespace pflib {
  */
 class DecodeAndBuffer : public Target::DAQRunConsumer {
   public:
-    DecodeAndBuffer(int nevents);
     virtual ~DecodeAndBuffer() = default;
-    /// Read out buffer
-    virtual std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
+    /// get buffer
+    std::vector<pflib::packing::SingleROCEventPacket> get_buffer();
+    /// Set the buffer size
+    void set_buffer_size(int nevents);
     /// Save to buffer
     virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) = 0;
-    /// Read out buffer
-    virtual std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
     /// Consumer for events
     virtual void consume(std::vector<uint32_t>& event) final;
     /// Check that the buffer was read and flushed since last run
@@ -44,11 +43,19 @@ class DecodeAndBuffer : public Target::DAQRunConsumer {
 };
 
 
+/**
+ * Subclass for implementation
+ * 
+ */
 class DecodeAndBufferToRead : public DecodeAndBuffer {
   public:
     DecodeAndBufferToRead(int nevents);
     virtual ~DecodeAndBufferToRead() = default;
-    virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) final;
+    virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) override {
+      DecodeAndBuffer::write_event(ep);
+    };
+    /// Read out buffer
+    std::vector<pflib::packing::SingleROCEventPacket> read_buffer();
 };
 
 }

--- a/include/pflib/DecodeAndWrite.h
+++ b/include/pflib/DecodeAndWrite.h
@@ -59,15 +59,17 @@ class DecodeAndWriteToCSV : public DecodeAndWrite {
 
 DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name);
 
-class DecodeAndWriteToBuffer : public DecodeAndWrite {
+class DecodeAndBuffer : public DecodeAndWrite {
   public:
-    DecodeAndWriteToBuffer();
-    virtual ~DecodeAndWriteToBuffer() = default;
+    DecodeAndBuffer();
+    virtual ~DecodeAndBuffer() = default;
     /// Read out buffer
-    virtual std::vector<pflib::packing::SingleROCEventPacket> read_data();
+    virtual std::vector<pflib::packing::SingleROCEventPacket> read_and_flush();
     /// Save to buffer
     virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) final;
-    // Safecheck if the buffer is getting too big (it's not being read out)
+    /// Check that the buffer was read and flushed since last run
+    virtual void start_run() override;
+    /// Failcheck if the buffer is getting too big
     virtual void end_run() override;
   private:
     /// Buffer to save event packets to

--- a/include/pflib/DecodeAndWrite.h
+++ b/include/pflib/DecodeAndWrite.h
@@ -58,4 +58,19 @@ class DecodeAndWriteToCSV : public DecodeAndWrite {
 
 DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name);
 
+class DecodeAndWriteToBuffer : public DecodeAndWrite {
+  public:
+    DecodeAndWriteToBuffer(const pflib::packing::SingleROCEventPacket& ep);
+    virtual ~DecodeAndWriteToBuffer() = default;
+    /// Read out buffer
+    std::vector<pflib::packing::SingleROCEventPacket> read_data();
+    /// Save to buffer
+    virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) final;
+    // Safecheck if the buffer is getting to big (it's not being read out)
+    virtual void end_run() override;
+  private:
+    /// Buffer to save event packets to
+    std::vector<plib::packing:SingleROCEventPacket> ep_buffer_;
+};
+
 }

--- a/include/pflib/DecodeAndWrite.h
+++ b/include/pflib/DecodeAndWrite.h
@@ -29,12 +29,14 @@ class DecodeAndWrite : public Target::DAQRunConsumer {
 
   /// pure virtual function for writing out decoded event
   virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) = 0;
+ 
+ protected:
+  /// logging for warning messages on empty events
+  mutable ::pflib::logging::logger the_log_;
 
  private:
   /// event packet for decoding
   pflib::packing::SingleROCEventPacket ep_;
-  /// logging for warning messages on empty events
-  mutable ::pflib::logging::logger the_log_;
 };
 
 /**

--- a/include/pflib/DecodeAndWrite.h
+++ b/include/pflib/DecodeAndWrite.h
@@ -59,21 +59,4 @@ class DecodeAndWriteToCSV : public DecodeAndWrite {
 
 DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name);
 
-class DecodeAndBuffer : public DecodeAndWrite {
-  public:
-    DecodeAndBuffer();
-    virtual ~DecodeAndBuffer() = default;
-    /// Read out buffer
-    virtual std::vector<pflib::packing::SingleROCEventPacket> read_and_flush();
-    /// Save to buffer
-    virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) final;
-    /// Check that the buffer was read and flushed since last run
-    virtual void start_run() override;
-    /// Failcheck if the buffer is getting too big
-    virtual void end_run() override;
-  private:
-    /// Buffer to save event packets to
-    std::vector<pflib::packing::SingleROCEventPacket> ep_buffer_;
-};
-
 }

--- a/include/pflib/DecodeAndWrite.h
+++ b/include/pflib/DecodeAndWrite.h
@@ -3,6 +3,7 @@
 #include <fstream>
 #include <memory>
 #include <functional>
+#include <vector>
 
 #include "pflib/packing/SingleROCEventPacket.h"
 #include "pflib/Logging.h"
@@ -60,17 +61,17 @@ DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name);
 
 class DecodeAndWriteToBuffer : public DecodeAndWrite {
   public:
-    DecodeAndWriteToBuffer(const pflib::packing::SingleROCEventPacket& ep);
+    DecodeAndWriteToBuffer();
     virtual ~DecodeAndWriteToBuffer() = default;
     /// Read out buffer
-    std::vector<pflib::packing::SingleROCEventPacket> read_data();
+    virtual std::vector<pflib::packing::SingleROCEventPacket> read_data();
     /// Save to buffer
     virtual void write_event(const pflib::packing::SingleROCEventPacket& ep) final;
-    // Safecheck if the buffer is getting to big (it's not being read out)
+    // Safecheck if the buffer is getting too big (it's not being read out)
     virtual void end_run() override;
   private:
     /// Buffer to save event packets to
-    std::vector<plib::packing:SingleROCEventPacket> ep_buffer_;
+    std::vector<pflib::packing::SingleROCEventPacket> ep_buffer_;
 };
 
 }

--- a/src/pflib/DecodeAndBuffer.cxx
+++ b/src/pflib/DecodeAndBuffer.cxx
@@ -5,6 +5,10 @@
 
 namespace pflib {
 
+DecodeAndBuffer::DecodeAndBuffer(int nevents) : DecodeAndWrite() {
+  set_buffer_size(nevents);
+}
+
 void DecodeAndBuffer::consume(std::vector<uint32_t>& event) {
   // we have to manually check the size so that we can do the reinterpret_cast
   if (event.size() == 0) {
@@ -20,7 +24,7 @@ void DecodeAndBuffer::consume(std::vector<uint32_t>& event) {
 }
 
 void DecodeAndBuffer::write_event(const pflib::packing::SingleROCEventPacket& ep) {
-  if (ep_buffer_.size() > buffer_size_) {
+  if (ep_buffer_.size() > ep_buffer_.capacity()) {
     pflib_log(warn) << "Trying to push more elements to buffer than allocated capacity. Skipping!";
     return;
   }
@@ -36,15 +40,10 @@ std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::get_buffer() 
 }
 
 void DecodeAndBuffer::set_buffer_size(int nevents) {
-  buffer_size_ = nevents;
-  ep_buffer_.reserve(buffer_size_);
+  ep_buffer_.reserve(nevents);
 }
 
-DecodeAndBufferToRead::DecodeAndBufferToRead(int nevents) : DecodeAndBuffer() {
-  set_buffer_size(nevents);
-}
-
-std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBufferToRead::read_buffer() {
+std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::read_buffer() {
   std::vector<pflib::packing::SingleROCEventPacket> buffer = get_buffer();
   return buffer;
 }

--- a/src/pflib/DecodeAndBuffer.cxx
+++ b/src/pflib/DecodeAndBuffer.cxx
@@ -1,0 +1,43 @@
+#include "pflib/DecodeAndBuffer.h"
+
+#include "pflib/packing/BufferReader.h"
+#include "pflib/Exception.h"
+
+namespace pflib {
+
+DecodeAndBuffer::DecodeAndBuffer(int nevents) {
+  buffer_size_ = nevents;
+  ep_buffer_.reserve(buffer_size_);
+}
+
+void DecodeAndBuffer::consume(std::vector<uint32_t>& event) {
+  // we have to manually check the size so that we can do the reinterpret_cast
+  if (event.size() == 0) {
+    pflib_log(warn) << "event with zero words passed in, skipping";
+    return;
+  }
+  // reinterpret the 32-bit words into a vector of bytes which is
+  // what is consummed by the BufferReader
+  const auto& buffer{*reinterpret_cast<const std::vector<uint8_t>*>(&event)};
+  pflib::packing::BufferReader r{buffer};
+  r >> ep_;
+  write_event(ep_);
+}
+
+void DecodeAndBuffer::write_event(const pflib::packing::SingleROCEventPacket& ep) {
+  if (ep_buffer_.size() > buffer_size_) {
+    pflib_log(warn) << "Trying to push more elements to buffer than allocated capacity. Skipping!";
+    return;
+  }
+  ep_buffer_.push_back(ep);
+}
+
+std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::read_buffer() {
+  return ep_buffer_;
+}
+
+void DecodeAndBuffer::start_run() {
+  ep_buffer_.clear();
+}
+
+}

--- a/src/pflib/DecodeAndBuffer.cxx
+++ b/src/pflib/DecodeAndBuffer.cxx
@@ -33,12 +33,12 @@ void DecodeAndBuffer::start_run() {
   ep_buffer_.clear();
 }
 
-DecodeAndBufferToRead::DecodeAndBufferToRead(int nevents) : DecodeAndBuffer() {
+DecodeAndBuffer::DecodeAndBuffer(int nevents) : DecodeAndBuffer() {
   buffer_size_ = nevents;
   ep_buffer_.reserve(buffer_size_);
 }
 
-std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBufferToRead::read_buffer() {
+std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::read_buffer() {
   return ep_buffer_;
 }
 

--- a/src/pflib/DecodeAndBuffer.cxx
+++ b/src/pflib/DecodeAndBuffer.cxx
@@ -21,17 +21,12 @@ void DecodeAndBuffer::start_run() {
   ep_buffer_.clear();
 }
 
-std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::get_buffer() {
+const std::vector<pflib::packing::SingleROCEventPacket>& DecodeAndBuffer::get_buffer() const {
   return ep_buffer_;
 }
 
 void DecodeAndBuffer::set_buffer_size(int nevents) {
   ep_buffer_.reserve(nevents);
-}
-
-std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::read_buffer() {
-  std::vector<pflib::packing::SingleROCEventPacket> buffer = get_buffer();
-  return buffer;
 }
 
 }

--- a/src/pflib/DecodeAndBuffer.cxx
+++ b/src/pflib/DecodeAndBuffer.cxx
@@ -5,10 +5,7 @@
 
 namespace pflib {
 
-DecodeAndBuffer::DecodeAndBuffer(int nevents) {
-  buffer_size_ = nevents;
-  ep_buffer_.reserve(buffer_size_);
-}
+
 
 void DecodeAndBuffer::consume(std::vector<uint32_t>& event) {
   // we have to manually check the size so that we can do the reinterpret_cast
@@ -32,12 +29,17 @@ void DecodeAndBuffer::write_event(const pflib::packing::SingleROCEventPacket& ep
   ep_buffer_.push_back(ep);
 }
 
-std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::read_buffer() {
-  return ep_buffer_;
-}
-
 void DecodeAndBuffer::start_run() {
   ep_buffer_.clear();
+}
+
+DecodeAndBufferToRead::DecodeAndBufferToRead(int nevents) : DecodeAndBuffer() {
+  buffer_size_ = nevents;
+  ep_buffer_.reserve(buffer_size_);
+}
+
+std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBufferToRead::read_buffer() {
+  return ep_buffer_;
 }
 
 }

--- a/src/pflib/DecodeAndBuffer.cxx
+++ b/src/pflib/DecodeAndBuffer.cxx
@@ -9,20 +9,6 @@ DecodeAndBuffer::DecodeAndBuffer(int nevents) : DecodeAndWrite() {
   set_buffer_size(nevents);
 }
 
-void DecodeAndBuffer::consume(std::vector<uint32_t>& event) {
-  // we have to manually check the size so that we can do the reinterpret_cast
-  if (event.size() == 0) {
-    pflib_log(warn) << "event with zero words passed in, skipping";
-    return;
-  }
-  // reinterpret the 32-bit words into a vector of bytes which is
-  // what is consummed by the BufferReader
-  const auto& buffer{*reinterpret_cast<const std::vector<uint8_t>*>(&event)};
-  pflib::packing::BufferReader r{buffer};
-  r >> ep_;
-  write_event(ep_);
-}
-
 void DecodeAndBuffer::write_event(const pflib::packing::SingleROCEventPacket& ep) {
   if (ep_buffer_.size() > ep_buffer_.capacity()) {
     pflib_log(warn) << "Trying to push more elements to buffer than allocated capacity. Skipping!";

--- a/src/pflib/DecodeAndBuffer.cxx
+++ b/src/pflib/DecodeAndBuffer.cxx
@@ -5,8 +5,6 @@
 
 namespace pflib {
 
-
-
 void DecodeAndBuffer::consume(std::vector<uint32_t>& event) {
   // we have to manually check the size so that we can do the reinterpret_cast
   if (event.size() == 0) {
@@ -33,13 +31,22 @@ void DecodeAndBuffer::start_run() {
   ep_buffer_.clear();
 }
 
-DecodeAndBuffer::DecodeAndBuffer(int nevents) : DecodeAndBuffer() {
+std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::get_buffer() {
+  return ep_buffer_;
+}
+
+void DecodeAndBuffer::set_buffer_size(int nevents) {
   buffer_size_ = nevents;
   ep_buffer_.reserve(buffer_size_);
 }
 
-std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::read_buffer() {
-  return ep_buffer_;
+DecodeAndBufferToRead::DecodeAndBufferToRead(int nevents) : DecodeAndBuffer() {
+  set_buffer_size(nevents);
+}
+
+std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBufferToRead::read_buffer() {
+  std::vector<pflib::packing::SingleROCEventPacket> buffer = get_buffer();
+  return buffer;
 }
 
 }

--- a/src/pflib/DecodeAndWrite.cxx
+++ b/src/pflib/DecodeAndWrite.cxx
@@ -3,6 +3,8 @@
 #include "pflib/packing/BufferReader.h"
 #include "pflib/Exception.h"
 
+#DEFINE MAXBUFFERSIZE = 10000;
+
 namespace pflib {
 
 void DecodeAndWrite::consume(std::vector<uint32_t>& event) {
@@ -47,21 +49,26 @@ DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name) {
   );
 }
 
-DecodeAndWriteToBuffer::DecodeAndWriteToBuffer() : DecodeAndWrite() {};
+DecodeAndBuffer::DecodeAndBuffer() : DecodeAndWrite() {};
 
-void DecodeAndWriteToBuffer::write_event(const pflib::packing::SingleROCEventPacket& ep) {
+void DecodeAndBuffer::write_event(const pflib::packing::SingleROCEventPacket& ep) {
   ep_buffer_.push_back(ep);
 }
 
-std::vector<pflib::packing::SingleROCEventPacket> DecodeAndWriteToBuffer::read_data() {
+std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::read_and_flush() {
   std::vector<pflib::packing::SingleROCEventPacket> data = ep_buffer_;
   ep_buffer_.clear();
   return data;
 }
 
-void DecodeAndWriteToBuffer::end_run() {
-  if (ep_buffer_.size() > 300) ep_buffer_.clear();
-  //this doesn't work.
+void DecodeAndBuffer::start_run() {
+  if (ep_buffer_.size() > 0) {
+    //pflib_log(warn) << "buffer was not read and flushed since last run"
+  }
+}
+
+void DecodeAndBuffer::end_run() {
+  if (ep_buffer_.size() > MAXBUFFERSIZE) ep_buffer_.clear();
   //pflib_log(warn) << "too many events saved in buffer. buffer cleared";
 }
 

--- a/src/pflib/DecodeAndWrite.cxx
+++ b/src/pflib/DecodeAndWrite.cxx
@@ -47,27 +47,4 @@ DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name) {
   );
 }
 
-DecodeAndBuffer::DecodeAndBuffer() : DecodeAndWrite() {};
-
-void DecodeAndBuffer::write_event(const pflib::packing::SingleROCEventPacket& ep) {
-  ep_buffer_.push_back(ep);
-}
-
-std::vector<pflib::packing::SingleROCEventPacket> DecodeAndBuffer::read_and_flush() {
-  std::vector<pflib::packing::SingleROCEventPacket> data = ep_buffer_;
-  ep_buffer_.clear();
-  return data;
-}
-
-void DecodeAndBuffer::start_run() {
-  if (ep_buffer_.size() > 0) {
-    //pflib_log(warn) << "buffer was not read and flushed since last run"
-  }
-}
-
-void DecodeAndBuffer::end_run() {
-  if (ep_buffer_.size() > 10000) ep_buffer_.clear();
-  //pflib_log(warn) << "too many events saved in buffer. buffer cleared";
-}
-
 }

--- a/src/pflib/DecodeAndWrite.cxx
+++ b/src/pflib/DecodeAndWrite.cxx
@@ -47,15 +47,22 @@ DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name) {
   );
 }
 
-DecodeAndWriteToBuffer::DecodeAndWriteToBuffer(const pflib::packing:SingleROCEventPacket& ep) : DecodeAndWrite() {};
+DecodeAndWriteToBuffer::DecodeAndWriteToBuffer() : DecodeAndWrite() {};
 
 void DecodeAndWriteToBuffer::write_event(const pflib::packing::SingleROCEventPacket& ep) {
   ep_buffer_.push_back(ep);
 }
 
+std::vector<pflib::packing::SingleROCEventPacket> DecodeAndWriteToBuffer::read_data() {
+  std::vector<pflib::packing::SingleROCEventPacket> data = ep_buffer_;
+  ep_buffer_.clear();
+  return data;
+}
+
 void DecodeAndWriteToBuffer::end_run() {
-  if (ep_buffer_.size() > 300) ep_buffer.clear();
-  pflib_log(warn) << "too many events saved in buffer. buffer cleared";
+  if (ep_buffer_.size() > 300) ep_buffer_.clear();
+  //this doesn't work.
+  //pflib_log(warn) << "too many events saved in buffer. buffer cleared";
 }
 
 }

--- a/src/pflib/DecodeAndWrite.cxx
+++ b/src/pflib/DecodeAndWrite.cxx
@@ -47,4 +47,15 @@ DecodeAndWriteToCSV all_channels_to_csv(const std::string& file_name) {
   );
 }
 
+DecodeAndWriteToBuffer::DecodeAndWriteToBuffer(const pflib::packing:SingleROCEventPacket& ep) : DecodeAndWrite() {};
+
+void DecodeAndWriteToBuffer::write_event(const pflib::packing::SingleROCEventPacket& ep) {
+  ep_buffer_.push_back(ep);
+}
+
+void DecodeAndWriteToBuffer::end_run() {
+  if (ep_buffer_.size() > 300) ep_buffer.clear();
+  pflib_log(warn) << "too many events saved in buffer. buffer cleared";
+}
+
 }

--- a/src/pflib/DecodeAndWrite.cxx
+++ b/src/pflib/DecodeAndWrite.cxx
@@ -3,8 +3,6 @@
 #include "pflib/packing/BufferReader.h"
 #include "pflib/Exception.h"
 
-#DEFINE MAXBUFFERSIZE = 10000;
-
 namespace pflib {
 
 void DecodeAndWrite::consume(std::vector<uint32_t>& event) {
@@ -68,7 +66,7 @@ void DecodeAndBuffer::start_run() {
 }
 
 void DecodeAndBuffer::end_run() {
-  if (ep_buffer_.size() > MAXBUFFERSIZE) ep_buffer_.clear();
+  if (ep_buffer_.size() > 10000) ep_buffer_.clear();
   //pflib_log(warn) << "too many events saved in buffer. buffer cleared";
 }
 


### PR DESCRIPTION
set_toa sets TOA_VREF for a specified channel. A small charge injection is sent to the channel, and the TOA_VREF is scanned. The first threshold with a toa efficiency of 1 is selected the "correct" toa for calibration as described in **José González Martínez's** _"Design and characterization of readout ASICs for SiPM detectors in pico-second timing measurements for the CMS HGCAL experiment"_ on page 99.

The function returns a parameter handle with the TOA_VREF for the specified channel.
Example of calling the function:
auto toa_handle = set_toa(tgt, roc, channel);