### PR TITLE
Patch compile value checking

### DIFF
--- a/src/pflib/Compile.cxx
+++ b/src/pflib/Compile.cxx
@@ -32,9 +32,14 @@ Compiler Compiler::get(const std::string& roc_type_version) {
 Compiler::Compiler(const ParameterLUT& parameter_lut, const PageLUT& page_lut)
     : parameter_lut_{parameter_lut}, page_lut_{page_lut} {}
 
-std::size_t msb(int i) {
+/**
+ * Calculate the Most Significant Bit of the input unsigned integer
+ *
+ * This is not safe and could be very slow if the value input is malformed
+ * (i.e. not a safely constructed unsigned integer).
+ */
+std::size_t msb(uint32_t v) {
   int r{0};
-  uint32_t v{static_cast<uint32_t>(i)};
   while (v >>= 1) {
     r++;
   }
@@ -47,6 +52,7 @@ void Compiler::compile(const std::string& page_name,
                        std::map<int, std::map<int, uint8_t>>& register_values) {
   const auto& page_id{parameter_lut_.at(page_name).first};
   const Parameter& spec{parameter_lut_.at(page_name).second.at(param_name)};
+  uint32_t uval{static_cast<uint32_t>(val)};
 
   std::size_t total_nbits = std::accumulate(
       spec.registers.begin(), spec.registers.end(), 0,
@@ -54,40 +60,20 @@ void Compiler::compile(const std::string& page_name,
         return bit_count + rhs.n_bits; 
       }
   );
-  std::size_t val_msb = msb(val);
+  std::size_t val_msb = msb(uval);
   if (val_msb >= total_nbits) {
     std::stringstream msg;
     msg << "Parameter " << page_name << '.' << param_name
         << " is being set to a value (" << val << ") exceeding its size ("
-        << total_nbits << " bits -> value < " << (1 << total_nbits) << ")";
+        << total_nbits << " bits -> value < " << (1u << total_nbits) << ")";
     PFEXCEPTION_RAISE("ValOver", msg.str());
   }
-
-  /*
-  if (total_nbits < 32) {
-    if (val < 0) {
-      PFEXCEPTION_RAISE("NegativeVal",
-          "Parameter "+page_name+"."+param_name
-          +" is being set to a negative value "+std::to_string(val)
-          +" which is not allowed in this register-based system.");
-    }
-  
-    if (val >= (1 << total_nbits)) {
-      std::stringstream msg;
-      msg << "Parameter " << page_name << '.' << param_name
-          << " is being set to a value (" << val << ") exceeding its size ("
-          << total_nbits << " bits -> value < " << (1 << total_nbits) << ")";
-      PFEXCEPTION_RAISE("ValOver", msg.str());
-    }
-  } else {
-  }
-  */
 
   std::size_t value_curr_min_bit{0};
   pflib_log(trace) << page_name << "." << param_name << " -> page " << page_id;
   for (const RegisterLocation& location : spec.registers) {
     // grab sub value of parameter in this register
-    uint8_t sub_val = ((val >> value_curr_min_bit) & location.mask);
+    uint8_t sub_val = ((uval >> value_curr_min_bit) & location.mask);
     pflib_log(trace) << "  " << sub_val << " at " << location.reg << ", "
                      << location.n_bits << " bits";
     value_curr_min_bit += location.n_bits;

--- a/src/pflib/Compile.cxx
+++ b/src/pflib/Compile.cxx
@@ -32,8 +32,9 @@ Compiler Compiler::get(const std::string& roc_type_version) {
 Compiler::Compiler(const ParameterLUT& parameter_lut, const PageLUT& page_lut)
     : parameter_lut_{parameter_lut}, page_lut_{page_lut} {}
 
-std::size_t msb(int v) {
+std::size_t msb(int i) {
   int r{0};
+  uint32_t v{static_cast<uint32_t>(i)};
   while (v >>= 1) {
     r++;
   }
@@ -41,7 +42,8 @@ std::size_t msb(int v) {
 }
 
 void Compiler::compile(const std::string& page_name,
-                       const std::string& param_name, const int& val,
+                       const std::string& param_name,
+                       const int& val,
                        std::map<int, std::map<int, uint8_t>>& register_values) {
   const auto& page_id{parameter_lut_.at(page_name).first};
   const Parameter& spec{parameter_lut_.at(page_name).second.at(param_name)};

--- a/test/compile.cxx
+++ b/test/compile.cxx
@@ -3,7 +3,6 @@
 
 #include <boost/test/unit_test.hpp>
 #include <fstream>
-#include <bitset>
 
 #include "pflib/Exception.h"
 

--- a/test/compile.cxx
+++ b/test/compile.cxx
@@ -3,6 +3,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include <fstream>
+#include <bitset>
 
 #include "pflib/Exception.h"
 
@@ -27,12 +28,10 @@ BOOST_AUTO_TEST_CASE(single_register_rocv3) {
   BOOST_CHECK_MESSAGE(registers == expected,
                       "multi-bit parameter setting not overwriting other "
                       "parameters in register");
-  // current behavior: silently trim parameters that are too large
-  c.compile("CH_45", "TRIM_TOA", 255, registers);
-  expected[11][1] = 0b11111110;
-  BOOST_CHECK_MESSAGE(
-      registers == expected,
-      "silently-trim parameter if larger than number of bits available");
+  BOOST_TEST_INFO("too-large values throw exceptions");
+  BOOST_CHECK_THROW(c.compile("CH_45", "TRIM_TOA", 255, registers), pflib::Exception);
+  BOOST_TEST_INFO("negative values throw exceptions");
+  BOOST_CHECK_THROW(c.compile("CH_45", "TRIM_TOA", -12, registers), pflib::Exception);
 }
 
 BOOST_AUTO_TEST_CASE(one_param_multi_registers) {
@@ -50,14 +49,27 @@ BOOST_AUTO_TEST_CASE(one_param_multi_registers) {
   BOOST_CHECK_MESSAGE(registers == expected,
                       "set parameter across multiple registers without "
                       "overwriting other parameters in register");
-  // bx_trigger is only 12 bits, so shifting 1 by 13 ends up setting it back to
-  // zero
-  c.compile("DIGITALHALF_0", "BX_TRIGGER", 1 << 13, registers);
-  expected[89][24] = 0;
-  expected[89][26] = 0b00001101;
-  BOOST_CHECK_MESSAGE(
-      registers == expected,
-      "silently trim parameter if larger than number of bits available");
+
+  BOOST_TEST_INFO("too-large values throw exceptions");
+  BOOST_CHECK_THROW(c.compile("DIGITALHALF_0", "BX_TRIGGER", 1 << 13, registers), pflib::Exception);
+}
+
+BOOST_AUTO_TEST_CASE(big_32bit_params) {
+  /**
+   * There are a few parameters that are a full 32 bits
+   * and I want to make sure we can handle them.
+   *
+   * For example, DIGITALHALF_1.SC_TESTRAM is 32 bits split
+   * across four registers. (page 43, registers 20-23)
+   */
+  pflib::Compiler c = pflib::Compiler::get("sipm_rocv3");
+  std::map<int, std::map<int, uint8_t>> registers, expected;
+  expected[43][20] = 0xab;
+  expected[43][21] = 0xcd;
+  expected[43][22] = 0xee;
+  expected[43][23] = 0xff;
+  c.compile("DIGITALHALF_1", "SC_TESTRAM", 0xffeecdab, registers);
+  BOOST_CHECK(registers == expected);
 }
 
 BOOST_AUTO_TEST_CASE(glob_pages) {


### PR DESCRIPTION
The compile value checking introduced by #180 is flawed for the large (32-bit) parameter values. It mistakenly thinks they are out of range (when they aren't). This patches that bug by changing how we check if a parameter value is in range.