### PR TITLE
switch base image to Rogue

### DIFF
--- a/env/Containerfile.bittware-host
+++ b/env/Containerfile.bittware-host
@@ -1,5 +1,6 @@
 FROM ghcr.io/slaclab/rogue:v6.6.2
 LABEL maintainer="Tom Eichlersmith <eichl008@umn.edu>"
+ENV ROGUE_DIR=/usr/local
 RUN apt-get update &&\
     apt-get --yes install \
       gcc \


### PR DESCRIPTION
This is helpful so the tests can make sure the Rogue-dependent code is compiling with the version of Rogue I believe we are using (6.6.2).