### PR TITLE
Make ECON readout batched

### DIFF
--- a/src/pflib/ECON.cxx
+++ b/src/pflib/ECON.cxx
@@ -236,14 +236,14 @@ void ECON::setRegisters(
 std::map<int, std::map<int, uint8_t>> ECON::getRegisters(
     const std::map<int, std::map<int, uint8_t>>& selected) {
   constexpr int MAX_BATCH_SIZE = 128;
-  
+
   std::map<int, std::map<int, uint8_t>> chip_reg;
   const int page_id = 0;
   std::map<int, uint8_t> all_regs;
 
   // Build sorted list of registers to read
   std::vector<std::pair<int, int>> reads_to_perform;  // (address, nbytes)
-  
+
   if (selected.empty()) {
     for (const auto& [reg_addr, nbytes] : econ_reg_nbytes_lut_) {
       reads_to_perform.emplace_back(reg_addr, nbytes);
@@ -264,12 +264,12 @@ std::map<int, std::map<int, uint8_t>> ECON::getRegisters(
   if (!reads_to_perform.empty()) {
     int start_addr = reads_to_perform[0].first;
     int current_end = start_addr + reads_to_perform[0].second;
-    
+
     for (size_t i = 1; i < reads_to_perform.size(); ++i) {
       int next_addr = reads_to_perform[i].first;
       int next_nbytes = reads_to_perform[i].second;
       int potential_size = next_addr + next_nbytes - start_addr;
-      
+
       // Check if contiguous AND under size limit
       if (next_addr == current_end && potential_size <= MAX_BATCH_SIZE) {
         // Extend the batch
@@ -278,17 +278,17 @@ std::map<int, std::map<int, uint8_t>> ECON::getRegisters(
         // Non-contiguous or too large - perform the batch
         int batch_size = current_end - start_addr;
         std::vector<uint8_t> batch_data = getValues(start_addr, batch_size);
-        
+
         for (int j = 0; j < batch_size; ++j) {
           all_regs[start_addr + j] = batch_data[j];
         }
-        
+
         // Start new batch
         start_addr = next_addr;
         current_end = next_addr + next_nbytes;
       }
     }
-    
+
     // Perform the final batch
     int batch_size = current_end - start_addr;
     std::vector<uint8_t> batch_data = getValues(start_addr, batch_size);

--- a/test/compile.cxx
+++ b/test/compile.cxx
@@ -312,12 +312,11 @@ BOOST_AUTO_TEST_CASE(full_lut_econd) {
       "The generated register LUT does not match the expected LUT");
 }
 
-
 BOOST_AUTO_TEST_CASE(read_three_aligner_params) {
   pflib::Compiler c = pflib::Compiler::get("econd");
-  
+
   std::map<int, std::map<int, uint8_t>> registers;
-  
+
   // First, set all registers to zero to avoid warnings
   auto reg_lut = c.build_register_byte_lut();
   for (const auto& [reg_addr, nbytes] : reg_lut) {
@@ -325,47 +324,53 @@ BOOST_AUTO_TEST_CASE(read_three_aligner_params) {
       registers[0][reg_addr + i] = 0;
     }
   }
-  
+
   // Now overwrite with our three parameters of interest
-  c.compile("ALIGNER", "GLOBAL_MATCH_PATTERN_VAL", 10760600711006082389ULL, registers);
+  c.compile("ALIGNER", "GLOBAL_MATCH_PATTERN_VAL", 10760600711006082389ULL,
+            registers);
   c.compile("ALIGNER", "GLOBAL_IDLE_HDR_VAL", 12, registers);
   c.compile("ALIGNER", "GLOBAL_ORBSYN_CNT_LOAD_VAL", 3514, registers);
-    
+
   // Decompile
   auto chip_params = c.decompile(registers, true, true);
   auto aligner_it = chip_params.find("ALIGNER");
   if (aligner_it != chip_params.end()) {
     const auto& params = aligner_it->second;
-    
+
     auto check_param = [&](const std::string& param_name, uint64_t expected) {
       auto it = params.find(param_name);
       if (it != params.end()) {
         bool match = (it->second == expected);
         std::cout << param_name << ":" << std::endl;
-        std::cout << "  Found:    " << std::dec << it->second 
-                  << " (0x" << std::hex << std::uppercase << it->second << ")" << std::endl;
-        std::cout << "  Expected: " << std::dec << expected 
-                  << " (0x" << std::hex << std::uppercase << expected << ")" << std::endl;
-        std::cout << "  Status:   " << (match ? "PASS ✓" : "FAIL ✗") << std::endl << std::endl;
+        std::cout << "  Found:    " << std::dec << it->second << " (0x"
+                  << std::hex << std::uppercase << it->second << ")"
+                  << std::endl;
+        std::cout << "  Expected: " << std::dec << expected << " (0x"
+                  << std::hex << std::uppercase << expected << ")" << std::endl;
+        std::cout << "  Status:   " << (match ? "PASS ✓" : "FAIL ✗")
+                  << std::endl
+                  << std::endl;
         BOOST_CHECK_EQUAL(it->second, expected);
       } else {
         std::cout << param_name << ":" << std::endl;
         std::cout << "  Status:   NOT FOUND ✗" << std::endl;
-        std::cout << "  Expected: " << std::dec << expected 
-                  << " (0x" << std::hex << std::uppercase << expected << ")" << std::endl << std::endl;
+        std::cout << "  Expected: " << std::dec << expected << " (0x"
+                  << std::hex << std::uppercase << expected << ")" << std::endl
+                  << std::endl;
         BOOST_FAIL("Parameter not found: " + param_name);
       }
     };
-    
+
     check_param("GLOBAL_MATCH_PATTERN_VAL", 10760600711006082389ULL);
     check_param("GLOBAL_IDLE_HDR_VAL", 12);
     check_param("GLOBAL_ORBSYN_CNT_LOAD_VAL", 3514);
   } else {
-    std::cout << "ERROR: ALIGNER page not found in decompiled output!" << std::endl;
+    std::cout << "ERROR: ALIGNER page not found in decompiled output!"
+              << std::endl;
     BOOST_FAIL("ALIGNER page not found");
   }
-  
+
   std::cout << "=== End of Test ===" << std::endl;
-} // end of BOOST_AUTO_TEST_CASE(read_three_aligner_params)
+}  // end of BOOST_AUTO_TEST_CASE(read_three_aligner_params)
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Maybe this resolves https://github.com/LDMX-Software/pflib/issues/266 ?

Now the ECON class also does things in batches, I dont know if this makes sense, but like this it's more like how the ROC does it and certainly will be faster. 

The following works:
```
[tamasvami@sdfiana007 pflib]$ time just _test -t "compile/single_register_econd"
cd build && denv ./test-pflib -t compile/single_register_econd
sed: can't read /usr/share/Modules/init/.modulespath: No such file or directory
Running 1 test case...

*** No errors detected

real	0m1.086s
user	0m0.195s
sys	0m0.703s
```

But we should test it in the real case too, so I'm opening this as a draft for now
