### PR TITLE
dont pass std::shared_ptr by reference

### DIFF
--- a/include/pflib/Bias.h
+++ b/include/pflib/Bias.h
@@ -45,7 +45,7 @@ class MAX5825 {
    * Wrap an I2C class for communicating with the MAX5825.
    * The bus we are on is the same as the ROC's bus.
    */
-  MAX5825(std::shared_ptr<I2C>& i2c, uint8_t max_addr);
+  MAX5825(std::shared_ptr<I2C> i2c, uint8_t max_addr);
 
   /**
    * Get the settings for the DACs on this MAX
@@ -114,7 +114,7 @@ class MAX5825 {
 
  private:
   /// our connection
-  std::shared_ptr<I2C>& i2c_;
+  std::shared_ptr<I2C> i2c_;
   /// our addr on the chip
   uint8_t our_addr_;
   /// our bus
@@ -148,7 +148,7 @@ class Bias {
    * The bus is 4 + <board-number>, so we set the default to 4 for
    * the case where we only have one board with bus number 0.
    */
-  Bias(std::shared_ptr<I2C>& i2c);
+  Bias(std::shared_ptr<I2C> i2c);
 
   /**
    * Initialize to standard settings

--- a/src/pflib/Bias.cxx
+++ b/src/pflib/Bias.cxx
@@ -19,7 +19,7 @@ const uint8_t MAX5825::CODEn_LOADn = 11 << 4;
 const uint8_t MAX5825::REFn = 2 << 4;
 const uint8_t MAX5825::POWERn = 4 << 4;
 
-MAX5825::MAX5825(std::shared_ptr<I2C>& i2c, uint8_t addr)
+MAX5825::MAX5825(std::shared_ptr<I2C> i2c, uint8_t addr)
     : i2c_{i2c}, our_addr_{addr} {}
 
 std::vector<uint8_t> MAX5825::get(uint8_t channel) {
@@ -53,7 +53,7 @@ const uint8_t Bias::ADDR_LED_1 = 0x1A;
 const uint8_t Bias::ADDR_SIPM_0 = 0x10;
 const uint8_t Bias::ADDR_SIPM_1 = 0x12;
 
-Bias::Bias(std::shared_ptr<I2C>& i2c) {
+Bias::Bias(std::shared_ptr<I2C> i2c) {
   led_.emplace_back(i2c, Bias::ADDR_LED_0);
   led_.emplace_back(i2c, Bias::ADDR_LED_1);
   sipm_.emplace_back(i2c, Bias::ADDR_SIPM_0);


### PR DESCRIPTION
This defeats the purpose of a std::shared_ptr which only knows to increment its reference count when it gets copied. When passing by reference, the reference counter does not get incremented, the original copies of std::shared_ptr are deleted and the object is destructed leading to a pointer that references invalid memory.