### PR TITLE
Board I2C initialization and temperature readout

### DIFF
--- a/app/tool/bias.cxx
+++ b/app/tool/bias.cxx
@@ -17,9 +17,9 @@ static void bias(const std::string& cmd, pflib::HcalBackplane* pft) {
     pflib::Bias bias = pft->bias(iboard);
     double temp = bias.readTemp();
     std::cout << "Board temperature: " << temp << " C" << std::endl;
-    for(int ch = 0; ch < 16; ch++){
-        std::cout << "Channel " << ch << " SiPM DAC " << bias.readSiPM(ch) 
-          << " LED DAC " << bias.readLED(ch) << std::endl;
+    for (int ch = 0; ch < 16; ch++) {
+      std::cout << "Channel " << ch << " SiPM DAC " << bias.readSiPM(ch)
+                << " LED DAC " << bias.readLED(ch) << std::endl;
     }
   }
   if (cmd == "READ_SIPM") {
@@ -109,12 +109,13 @@ static void bias_wrapper(const std::string& cmd, Target* tgt) {
 }
 
 namespace {
-auto menu_bias = pftool::menu("BIAS", "Read and write bias voltages", render)
-                     ->line("STATUS", "Bias and board I2C summary", bias_wrapper)
-                     ->line("INIT", "Board I2C Initialization", bias_wrapper)
-                     ->line("READ_SIPM", "Read SiPM DAC values", bias_wrapper)
-                     ->line("READ_LED", "Read LED DAC values", bias_wrapper)
-                     ->line("SET_SIPM", "Set SiPM DAC values", bias_wrapper)
-                     ->line("SET_LED", "Set LED DAC values", bias_wrapper)
-                     ->line("READ_TEMP", "Read temperature", bias_wrapper);
+auto menu_bias =
+    pftool::menu("BIAS", "Read and write bias voltages", render)
+        ->line("STATUS", "Bias and board I2C summary", bias_wrapper)
+        ->line("INIT", "Board I2C Initialization", bias_wrapper)
+        ->line("READ_SIPM", "Read SiPM DAC values", bias_wrapper)
+        ->line("READ_LED", "Read LED DAC values", bias_wrapper)
+        ->line("SET_SIPM", "Set SiPM DAC values", bias_wrapper)
+        ->line("SET_LED", "Set LED DAC values", bias_wrapper)
+        ->line("READ_TEMP", "Read temperature", bias_wrapper);
 }

--- a/include/pflib/Bias.h
+++ b/include/pflib/Bias.h
@@ -1,8 +1,9 @@
 #ifndef PFLIB_MAX5825_H_
 #define PFLIB_MAX5825_H_
 
-#include <vector>
 #include <unistd.h>
+
+#include <vector>
 
 #include "pflib/I2C.h"
 
@@ -162,9 +163,6 @@ class Bias {
   int readLED(uint8_t i_led);
   void setSiPM(uint8_t i_sipm, uint16_t code);
   void setLED(uint8_t i_led, uint16_t code);
-
-
-
 
  private:
   std::shared_ptr<I2C> i2c_;

--- a/src/pflib/Bias.cxx
+++ b/src/pflib/Bias.cxx
@@ -56,51 +56,49 @@ Bias::Bias(std::shared_ptr<I2C> i2c) {
 }
 
 void Bias::initialize() {
+  // Reset all DAC:s
+  i2c_->general_write_read(0x10, {0x35, 0x96, 0x30}, 0);
+  i2c_->general_write_read(0x12, {0x35, 0x96, 0x30}, 0);
+  i2c_->general_write_read(0x14, {0x35, 0x96, 0x30}, 0);
+  i2c_->general_write_read(0x18, {0x35, 0x96, 0x30}, 0);
 
- // Reset all DAC:s
- i2c_->general_write_read(0x10, {0x35,0x96,0x30}, 0); 
- i2c_->general_write_read(0x12, {0x35,0x96,0x30}, 0); 
- i2c_->general_write_read(0x14, {0x35,0x96,0x30}, 0); 
- i2c_->general_write_read(0x18, {0x35,0x96,0x30}, 0); 
+  // Set internal ref on DAC to 4.096 V
+  i2c_->general_write_read(0x10, {0x27, 0x00, 0x00}, 0);
+  i2c_->general_write_read(0x12, {0x27, 0x00, 0x00}, 0);
+  i2c_->general_write_read(0x14, {0x27, 0x00, 0x00}, 0);
+  i2c_->general_write_read(0x18, {0x27, 0x00, 0x00}, 0);
 
- // Set internal ref on DAC to 4.096 V
- i2c_->general_write_read(0x10, {0x27,0x00,0x00}, 0); 
- i2c_->general_write_read(0x12, {0x27,0x00,0x00}, 0); 
- i2c_->general_write_read(0x14, {0x27,0x00,0x00}, 0); 
- i2c_->general_write_read(0x18, {0x27,0x00,0x00}, 0); 
+  // Set up the GPIO device MCP23008
+  i2c_->general_write_read(0x20, {0x00, 0x70}, 0);
 
- // Set up the GPIO device MCP23008
- i2c_->general_write_read(0x20, {0x00,0x70}, 0); 
+  // Turn on the status LED
+  i2c_->general_write_read(0x20, {0x09, 0x80}, 0);
 
- // Turn on the status LED 
- i2c_->general_write_read(0x20, {0x09,0x80}, 0); 
+  // Set up the board temperature sensor TMP101
+  i2c_->general_write_read(0x4A, {0x01, 0x60}, 0);
 
- // Set up the board temperature sensor TMP101
- i2c_->general_write_read(0x4A, {0x01,0x60}, 0); 
-
- // Set up the two onewire-to-I2C devices DS2482
- // Reset
- i2c_->general_write_read(0x1C, {0xF0}, 0);
- // Standard speed, weak pull-up, no active pull-up
- i2c_->general_write_read(0x1C, {0xC3, 0xF0}, 0); 
- i2c_->general_write_read(0x1D, {0xF0}, 0); 
- i2c_->general_write_read(0x1D, {0xC3, 0xF0}, 0); 
-
+  // Set up the two onewire-to-I2C devices DS2482
+  // Reset
+  i2c_->general_write_read(0x1C, {0xF0}, 0);
+  // Standard speed, weak pull-up, no active pull-up
+  i2c_->general_write_read(0x1C, {0xC3, 0xF0}, 0);
+  i2c_->general_write_read(0x1D, {0xF0}, 0);
+  i2c_->general_write_read(0x1D, {0xC3, 0xF0}, 0);
 }
 
-double Bias::readTemp(){
+double Bias::readTemp() {
+  i2c_->general_write_read(0x4A, {0x00}, 0);
+  usleep(250);  // Response is a bit slow
+  std::vector<uint8_t> ret = i2c_->general_write_read(0x4A, {}, 2);
 
- i2c_->general_write_read(0x4A, {0x00}, 0); 
- usleep(250); // Response is a bit slow
- std::vector<uint8_t> ret = i2c_->general_write_read(0x4A, {}, 2); 
-
- int dec = 625*((ret.at(0)*256 + ret.at(1)) >> 4);
- int integer = dec/10000;
- int decimal = dec - integer*10000;
- char cs[10];
- snprintf(cs, 10,"%d.%d", integer, decimal);
- std::string str = cs;
- return std::stod(str);;
+  int dec = 625 * ((ret.at(0) * 256 + ret.at(1)) >> 4);
+  int integer = dec / 10000;
+  int decimal = dec - integer * 10000;
+  char cs[10];
+  snprintf(cs, 10, "%d.%d", integer, decimal);
+  std::string str = cs;
+  return std::stod(str);
+  ;
 }
 
 int Bias::readSiPM(uint8_t channel) {


### PR DESCRIPTION
Partially solves #290 by adding the board I2C init sequence (resetting some registers and setting some reference voltages), and the board temperature readout, to the BIAS submenu. 