### PR TITLE
311 make it easier to set bus speed and so do for bias

### DIFF
--- a/include/pflib/lpGBT.h
+++ b/include/pflib/lpGBT.h
@@ -208,26 +208,36 @@ class lpGBT {
 
   uint32_t read_efuse(uint16_t addr);
 
-  /** Setup an I2C bus
-      \param ibus Which I2C bus (0-2)
-      \param speed_khz I2C speed (appropriate values are 100, 200, 400, 1000)
-      \param scl_drive Enable CMOS driver on SCL
-      \param strong_scl Enable higher-strength driver on SCL
-      \param strong_sda Enable higher-strength driver on SDA
-      \param pull_up_scl Enable internal pullup on SCL
-      \param pull_up_sda Enable internal pullup on SDA
+  /**
+   * Setup an I2C bus
+   * @param ibus Which I2C bus (0-2)
+   * @param speed_khz I2C speed (appropriate values are 100, 200, 400, 1000)
+   * @param scl_drive Enable CMOS driver on SCL
+   * @param strong_scl Enable higher-strength driver on SCL
+   * @param strong_sda Enable higher-strength driver on SDA
+   * @param pull_up_scl Enable internal pullup on SCL
+   * @param pull_up_sda Enable internal pullup on SDA
+   *
+   * @note This just stores information in memory and does *not* configure the
+   * lpGBT, so it needs to be done on every launch of an executable.
    */
   void setup_i2c(int ibus, int speed_khz, bool scl_drive = false,
                  bool strong_scl = true, bool strong_sda = true,
                  bool pull_up_scl = false, bool pull_up_sda = false);
 
-  /** Setup i2c bus speed
-      \param ibus Which I2C bus (0-2)
-      \param speed_khz I2C speed (appropriate values are 100, 200, 400, 1000)
-      Note that this really just stores the information on what speed to use in
-     a temporary variable
+  /**
+   * Setup i2c bus speed
+   * @param ibus Which I2C bus (0-2)
+   * @param speed_khz I2C speed (appropriate values are 100, 200, 400, 1000)
    */
   void setup_i2c_speed(int ibus, int speed_khz);
+
+  /**
+   * Get the i2c bus speed
+   * @param ibus which I2C bus (0-2)
+   * @return speed in kHz of the I2C bus (100, 200, 400, or 1000)
+   */
+  int get_i2c_speed(int ibus);
 
   /** Start an I2C read */
   void start_i2c_read(int ibus, uint8_t i2c_addr, int len = 1);

--- a/include/pflib/lpGBT.h
+++ b/include/pflib/lpGBT.h
@@ -224,7 +224,8 @@ class lpGBT {
   /** Setup i2c bus speed
       \param ibus Which I2C bus (0-2)
       \param speed_khz I2C speed (appropriate values are 100, 200, 400, 1000)
-      Note that this really just stores the information on what speed to use in a temporary variable
+      Note that this really just stores the information on what speed to use in
+     a temporary variable
    */
   void setup_i2c_speed(int ibus, int speed_khz);
 

--- a/include/pflib/lpGBT.h
+++ b/include/pflib/lpGBT.h
@@ -221,6 +221,13 @@ class lpGBT {
                  bool strong_scl = true, bool strong_sda = true,
                  bool pull_up_scl = false, bool pull_up_sda = false);
 
+  /** Setup i2c bus speed
+      \param ibus Which I2C bus (0-2)
+      \param speed_khz I2C speed (appropriate values are 100, 200, 400, 1000)
+      Note that this really just stores the information on what speed to use in a temporary variable
+   */
+  void setup_i2c_speed(int ibus, int speed_khz);
+
   /** Start an I2C read */
   void start_i2c_read(int ibus, uint8_t i2c_addr, int len = 1);
 

--- a/include/pflib/lpgbt/I2C.h
+++ b/include/pflib/lpgbt/I2C.h
@@ -10,7 +10,7 @@ namespace lpgbt {
 /** Synchronous I2C implementation */
 class I2C : public ::pflib::I2C {
  public:
-  I2C(lpGBT& lpGBT, int ibus) : lpgbt_{lpGBT}, ibus_{ibus}, ispeed_{100} {}
+  I2C(lpGBT& lpGBT, int ibus) : lpgbt_{lpGBT}, ibus_{ibus} {}
 
   virtual void set_bus_speed(int speed = 100);
   virtual int get_bus_speed();
@@ -22,7 +22,6 @@ class I2C : public ::pflib::I2C {
  private:
   lpGBT& lpgbt_;
   int ibus_;
-  int ispeed_;
 };
 
 /** Synchronous I2C implementation */

--- a/src/pflib/Bias.cxx
+++ b/src/pflib/Bias.cxx
@@ -25,6 +25,7 @@ MAX5825::MAX5825(std::shared_ptr<I2C> i2c, uint8_t addr)
 std::vector<uint8_t> MAX5825::get(uint8_t channel) {
   uint8_t cmd = (uint8_t)(MAX5825::CODEn | (channel & 0x07));
 
+  i2c_->set_bus_speed(100);
   std::vector<uint8_t> retval = i2c_->general_write_read(our_addr_, {cmd}, 2);
 
   return retval;
@@ -33,6 +34,7 @@ std::vector<uint8_t> MAX5825::get(uint8_t channel) {
 void MAX5825::set(uint8_t channel, uint16_t code) {
   uint8_t cmd = (uint8_t)(0xB0 | (channel & 0x07));
 
+  i2c_->set_bus_speed(100);
   std::vector<uint8_t> retval =
       i2c_->general_write_read(our_addr_,
                                {cmd, static_cast<uint8_t>((code << 4) >> 8),
@@ -58,18 +60,21 @@ Bias::Bias(std::shared_ptr<I2C> i2c_bias, std::shared_ptr<I2C> i2c_board) {
 
 void Bias::initialize() {
   // Reset all DAC:s
+  i2c_bias_->set_bus_speed(100);
   i2c_bias_->general_write_read(0x10, {0x35, 0x96, 0x30}, 0);
   i2c_bias_->general_write_read(0x12, {0x35, 0x96, 0x30}, 0);
   i2c_bias_->general_write_read(0x14, {0x35, 0x96, 0x30}, 0);
   i2c_bias_->general_write_read(0x18, {0x35, 0x96, 0x30}, 0);
 
   // Set internal ref on DAC to 4.096 V
+  i2c_bias_->set_bus_speed(100);
   i2c_bias_->general_write_read(0x10, {0x27, 0x00, 0x00}, 0);
   i2c_bias_->general_write_read(0x12, {0x27, 0x00, 0x00}, 0);
   i2c_bias_->general_write_read(0x14, {0x27, 0x00, 0x00}, 0);
   i2c_bias_->general_write_read(0x18, {0x27, 0x00, 0x00}, 0);
 
   // Set up the GPIO device MCP23008
+  i2c_board_->set_bus_speed(100);
   i2c_board_->general_write_read(0x20, {0x00, 0x70}, 0);
 
   // Turn on the status LED
@@ -88,6 +93,7 @@ void Bias::initialize() {
 }
 
 double Bias::readTemp() {
+  i2c_board_->set_bus_speed(100);
   i2c_board_->general_write_read(0x4A, {0x00}, 0);
   usleep(250);  // Response is a bit slow
   std::vector<uint8_t> ret = i2c_board_->general_write_read(0x4A, {}, 2);

--- a/src/pflib/lpGBT.cxx
+++ b/src/pflib/lpGBT.cxx
@@ -687,8 +687,8 @@ void lpGBT::setup_i2c(int ibus, int speed_khz, bool scl_drive, bool strong_scl,
 
 void lpGBT::setup_i2c_speed(int ibus, int speed_khz) {
   if (ibus < 0 || ibus > 2) return;
-  
-  i2c_[ibus].ctl_reg &= 0x80; // keep the scl_drive
+
+  i2c_[ibus].ctl_reg &= 0x80;  // keep the scl_drive
   if (speed_khz > 125 && speed_khz < 300) i2c_[ibus].ctl_reg |= 0x01;
   if (speed_khz > 300 && speed_khz < 500) i2c_[ibus].ctl_reg |= 0x02;
   if (speed_khz > 500 && speed_khz < 2000) i2c_[ibus].ctl_reg |= 0x03;

--- a/src/pflib/lpGBT.cxx
+++ b/src/pflib/lpGBT.cxx
@@ -685,6 +685,15 @@ void lpGBT::setup_i2c(int ibus, int speed_khz, bool scl_drive, bool strong_scl,
   if (speed_khz > 500 && speed_khz < 2000) i2c_[ibus].ctl_reg |= 0x03;
 }
 
+void lpGBT::setup_i2c_speed(int ibus, int speed_khz) {
+  if (ibus < 0 || ibus > 2) return;
+  
+  i2c_[ibus].ctl_reg &= 0x80; // keep the scl_drive
+  if (speed_khz > 125 && speed_khz < 300) i2c_[ibus].ctl_reg |= 0x01;
+  if (speed_khz > 300 && speed_khz < 500) i2c_[ibus].ctl_reg |= 0x02;
+  if (speed_khz > 500 && speed_khz < 2000) i2c_[ibus].ctl_reg |= 0x03;
+}
+
 static constexpr uint8_t CMD_I2C_WRITE_CR = 0;
 static constexpr uint8_t CMD_I2C_1BYTE_WRITE = 2;
 static constexpr uint8_t CMD_I2C_1BYTE_READ = 3;

--- a/src/pflib/lpGBT.cxx
+++ b/src/pflib/lpGBT.cxx
@@ -680,18 +680,34 @@ void lpGBT::setup_i2c(int ibus, int speed_khz, bool scl_drive, bool strong_scl,
 
   i2c_[ibus].ctl_reg = 0;
   if (scl_drive) i2c_[ibus].ctl_reg |= 0x80;
-  if (speed_khz > 125 && speed_khz < 300) i2c_[ibus].ctl_reg |= 0x01;
-  if (speed_khz > 300 && speed_khz < 500) i2c_[ibus].ctl_reg |= 0x02;
-  if (speed_khz > 500 && speed_khz < 2000) i2c_[ibus].ctl_reg |= 0x03;
+  setup_i2c_speed(ibus, speed_khz);
 }
 
 void lpGBT::setup_i2c_speed(int ibus, int speed_khz) {
   if (ibus < 0 || ibus > 2) return;
 
-  i2c_[ibus].ctl_reg &= 0x80;  // keep the scl_drive
+  // keep scl_drive while clearing any previous speed setting
+  i2c_[ibus].ctl_reg &= 0x80;
   if (speed_khz > 125 && speed_khz < 300) i2c_[ibus].ctl_reg |= 0x01;
   if (speed_khz > 300 && speed_khz < 500) i2c_[ibus].ctl_reg |= 0x02;
   if (speed_khz > 500 && speed_khz < 2000) i2c_[ibus].ctl_reg |= 0x03;
+}
+
+int lpGBT::get_i2c_speed(int ibus) {
+  int speed_code = (i2c_[ibus].ctl_reg & 0x3);
+  switch (speed_code) {
+    case 0b00:
+      return 100;
+    case 0b01:
+      return 200;
+    case 0b10:
+      return 400;
+    case 0b11:
+      return 1000;
+    default:
+      throw std::logic_error("i thought i covered all possible 2-bit values");
+  }
+  return 0;
 }
 
 static constexpr uint8_t CMD_I2C_WRITE_CR = 0;

--- a/src/pflib/lpgbt/I2C.cxx
+++ b/src/pflib/lpgbt/I2C.cxx
@@ -5,7 +5,7 @@ namespace lpgbt {
 
 void I2C::set_bus_speed(int speed) {
   ispeed_ = speed;
-  lpgbt_.setup_i2c(ibus_, speed);
+  lpgbt_.setup_i2c_speed(ibus_, speed);
 }
 
 int I2C::get_bus_speed() { return ispeed_; }

--- a/src/pflib/lpgbt/I2C.cxx
+++ b/src/pflib/lpgbt/I2C.cxx
@@ -4,11 +4,12 @@ namespace pflib {
 namespace lpgbt {
 
 void I2C::set_bus_speed(int speed) {
-  ispeed_ = speed;
   lpgbt_.setup_i2c_speed(ibus_, speed);
 }
 
-int I2C::get_bus_speed() { return ispeed_; }
+int I2C::get_bus_speed() {
+  return lpgbt_.get_i2c_speed(ibus_);
+}
 
 void I2C::write_byte(uint8_t i2c_dev_addr, uint8_t data) {
   lpgbt_.i2c_write(ibus_, i2c_dev_addr, data);

--- a/src/pflib/lpgbt/I2C.cxx
+++ b/src/pflib/lpgbt/I2C.cxx
@@ -3,13 +3,9 @@
 namespace pflib {
 namespace lpgbt {
 
-void I2C::set_bus_speed(int speed) {
-  lpgbt_.setup_i2c_speed(ibus_, speed);
-}
+void I2C::set_bus_speed(int speed) { lpgbt_.setup_i2c_speed(ibus_, speed); }
 
-int I2C::get_bus_speed() {
-  return lpgbt_.get_i2c_speed(ibus_);
-}
+int I2C::get_bus_speed() { return lpgbt_.get_i2c_speed(ibus_); }
 
 void I2C::write_byte(uint8_t i2c_dev_addr, uint8_t data) {
   lpgbt_.i2c_write(ibus_, i2c_dev_addr, data);


### PR DESCRIPTION
Makes the lpGBT bus speed setting simpler and applies 100 kHz to all the Bias interactions.  Probably should change code to restore whatever speed was there before for the non-bias interactions (e.g. ROC)