### PR TITLE
Move GPIO calls outside of the setup functions

### DIFF
--- a/include/pflib/lpgbt/lpGBT_standard_configs.h
+++ b/include/pflib/lpgbt/lpGBT_standard_configs.h
@@ -9,9 +9,14 @@ namespace standard_config {
 
 /** Setup the standard set of I/Os for the HCAL backplane DAQ lpGBT */
 void setup_hcal_daq(pflib::lpGBT&);
+/** Setup the GPIO names for the HCAL backplane DAQ lpGBT */
+void setup_hcal_daq_gpio(pflib::lpGBT&);
+void setup_hcal_trig_gpio(pflib::lpGBT&);
 
 /** Setup the standard set of I/Os for the HCAL backplane TRIG lpGBT */
 void setup_hcal_trig(pflib::lpGBT&);
+/** Setup the GPIO names for the ECAL DAQ*/
+void setup_ecal_daq_gpio(pflib::lpGBT&);
 
 /** Setup the lpGBT to train the eRx phase */
 void setup_erxtraining(pflib::lpGBT&, bool prbs_on);

--- a/src/pflib/bittware/EcalSMMTarget.cxx
+++ b/src/pflib/bittware/EcalSMMTarget.cxx
@@ -39,16 +39,24 @@ class EcalSMMTargetBW : public Target {
 
     using namespace pflib::lpgbt::standard_config;
 
-    // Apply standard ECAL configuration for DAQ lpGBT
+    // Setup DAQ lpGBT
     try {
-      pflib_log(debug) << "Apply standard ECAL config";
-      try {
-        setup_ecal(*daq_lpgbt_, ECAL_lpGBT_Config::DAQ_SingleModuleMotherboard);
-      } catch (const pflib::Exception& e) {
-        pflib_log(warn) << "Failure to apply standard config [" << e.name()
-                        << "]: " << e.message();
-      }
+      int daq_pusm = daq_lpgbt_->status();
+      pflib::lpgbt::standard_config::setup_ecal_daq_gpio(*daq_lpgbt_);
 
+      if (daq_pusm == 19) {
+        pflib_log(debug) << "DAQ lpGBT is PUSM READY (19)";
+      } else {
+        pflib_log(debug)
+            << "DAQ lpGBT is not ready, attempting standard config";
+        try {
+          setup_ecal(*daq_lpgbt_,
+                     ECAL_lpGBT_Config::DAQ_SingleModuleMotherboard);
+        } catch (const pflib::Exception& e) {
+          pflib_log(warn) << "Failure to apply standard config [" << e.name()
+                          << "]: " << e.message();
+        }
+      }
     } catch (const pflib::Exception& e) {
       pflib_log(debug) << "unable to I2C transact with lpGBT, advising user to "
                           "check Optical links";
@@ -58,16 +66,22 @@ class EcalSMMTargetBW : public Target {
                       << " and then re-open pftool.";
     }
 
-    // Apply standard ECAL configuration for TRG lpGBT
+    // Setup TRG lpGBT
     try {
-      pflib_log(debug) << " Apply standard ECAL TRG config";
-      try {
-        setup_ecal(*trig_lpgbt_,
-                   ECAL_lpGBT_Config::TRIG_SingleModuleMotherboard);
-      } catch (const pflib::Exception& e) {
-        pflib_log(info) << "Not Critical Problem setting up TRIGGER lpGBT.";
-        pflib_log(info) << "Failure to apply standard config [" << e.name()
-                        << "]: " << e.message();
+      int trg_pusm = trig_lpgbt_->status();
+      if (trg_pusm == 19) {
+        pflib_log(debug) << "TRG lpGBT is PUSM READY (19)";
+      } else {
+        pflib_log(debug)
+            << "TRG lpGBT is not ready, attempting standard config";
+        try {
+          setup_ecal(*trig_lpgbt_,
+                     ECAL_lpGBT_Config::TRIG_SingleModuleMotherboard);
+        } catch (const pflib::Exception& e) {
+          pflib_log(info) << "Not Critical Problem setting up TRIGGER lpGBT.";
+          pflib_log(info) << "Failure to apply standard config [" << e.name()
+                          << "]: " << e.message();
+        }
       }
     } catch (const pflib::Exception& e) {
       pflib_log(info) << "(Not Critical) Failure to check TRG lpGBT status ["

--- a/src/pflib/bittware/HcalBackplaneBittware.cxx
+++ b/src/pflib/bittware/HcalBackplaneBittware.cxx
@@ -35,18 +35,49 @@ class HcalBackplaneBW : public HcalBackplane {
     trig_lpgbt_ =
         std::make_unique<pflib::lpGBT>(opto_["TRG"]->lpgbt_transport());
 
+    // Load GPIO configuration for lpGBTs
+    pflib::lpgbt::standard_config::setup_hcal_daq_gpio(*daq_lpgbt_);
+    pflib::lpgbt::standard_config::setup_hcal_trig_gpio(*trig_lpgbt_);
+
+    // Setup lpGBTs
     try {
-      pflib_log(debug) << "Apply standard HCAL config";
-      try {
-        pflib_log(debug) << "applying DAQ";
-        pflib::lpgbt::standard_config::setup_hcal_daq(*daq_lpgbt_);
-        pflib_log(debug) << "pause to let hardware re-sync";
-        sleep(2);
-        pflib_log(debug) << "applying TRIG";
-        pflib::lpgbt::standard_config::setup_hcal_trig(*trig_lpgbt_);
-      } catch (const pflib::Exception& e) {
-        pflib_log(warn) << "Failure to apply standard config [" << e.name()
-                        << "]: " << e.message();
+      int daq_pusm = daq_lpgbt_->status();
+      int trg_pusm = trig_lpgbt_->status();
+      if (daq_pusm == 19 and trg_pusm == 19) {
+        // both lpGBTs are PUSM READY
+        pflib_log(debug) << "both lpGBTs are have status PUSM READY (19)";
+      } else if (daq_pusm != 19 and trg_pusm == 19) {
+        pflib_log(debug) << "TRG lpGBT has status PUSM READY (19)";
+        pflib_log(debug) << "applying standard DAQ lpGBT configuration";
+        try {
+          pflib::lpgbt::standard_config::setup_hcal_daq(*daq_lpgbt_);
+        } catch (const pflib::Exception& e) {
+          pflib_log(warn) << "Failure to apply standard config [" << e.name()
+                          << "]: " << e.message();
+        }
+      } else if (daq_pusm == 19 and trg_pusm != 19) {
+        pflib_log(debug) << "DAQ lpGBT has status PUSM READY (19)";
+        pflib_log(debug) << "applying standard TRG lpGBT configuration";
+        try {
+          pflib::lpgbt::standard_config::setup_hcal_trig(*trig_lpgbt_);
+        } catch (const pflib::Exception& e) {
+          pflib_log(warn) << "Failure to apply standard config [" << e.name()
+                          << "]: " << e.message();
+        }
+      } else /* both are not PUSM READY */ {
+        pflib_log(debug) << "neither lpGBT have status PUSM READY (19)";
+        pflib_log(debug) << "applying standard lpGBT configuration";
+        try {
+          pflib_log(debug) << "applying DAQ";
+          pflib::lpgbt::standard_config::setup_hcal_daq(*daq_lpgbt_);
+          pflib_log(debug) << "pause to let hardware re-sync";
+          sleep(2);
+          pflib_log(debug) << "applying TRIG";
+          pflib::lpgbt::standard_config::setup_hcal_trig(*trig_lpgbt_);
+        } catch (const pflib::Exception& e) {
+          pflib_log(warn) << "Failure to apply standard config [" << e.name()
+                          << "]: " << e.message();
+        }
       }
     } catch (const pflib::Exception& e) {
       pflib_log(debug) << "unable to I2C transact with lpGBT, advising user to "

--- a/src/pflib/lpGBT.cxx
+++ b/src/pflib/lpGBT.cxx
@@ -409,7 +409,7 @@ void lpGBT::check_prbs_errors_erx(int group, int channel, bool lpgbt_only,
         (now.tv_sec - start.tv_sec) * 1000000L + (now.tv_usec - start.tv_usec);
     // Wait two seconds
     if (elapsed_us > 2000000) {
-      printf(" INFO: Current lock state = %d\n", group, state);
+      printf(" INFO: Current lock state = %d %d\n", group, state);
       break;
     }
     usleep(1000);
@@ -669,7 +669,7 @@ bool lpGBT::i2c_transaction_check(int ibus, bool wait) {
     if (val & SUCCESS) {
       return true;
     }
-    usleep(100);  //
+    usleep(100);
   } while (wait);
   return false;
 }

--- a/src/pflib/lpgbt/lpGBT_standard_configs.cxx
+++ b/src/pflib/lpgbt/lpGBT_standard_configs.cxx
@@ -4,33 +4,38 @@ namespace pflib {
 namespace lpgbt {
 namespace standard_config {
 
-void setup_hcal_daq(pflib::lpGBT& lpgbt) {
+void setup_hcal_daq_gpio(pflib::lpGBT& lpgbt) {
   // setup the reset lines
   // each call configures the pin number, mode, and assigns a name
   // then we set an initial value (true = high, false = low)
   lpgbt.gpio_cfg_set(
       0, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "HGCROC2_HRST");
-  lpgbt.gpio_set(0, true);
   lpgbt.gpio_cfg_set(
       1, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "HGCROC2_SRST");
-  lpgbt.gpio_set(1, true);
   lpgbt.gpio_cfg_set(
       2, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "HGCROC1_HRST");
-  lpgbt.gpio_set(2, true);
   lpgbt.gpio_cfg_set(
       4, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "HGCROC1_SRST");
-  lpgbt.gpio_set(4, true);
   lpgbt.gpio_cfg_set(
       8, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "HGCROC_I2C_RST");
-  lpgbt.gpio_set(8, true);
   lpgbt.gpio_cfg_set(
       11, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "TRIG_LPGBT_RSTB");
+
+}  // end of setup_hcal_daq_gpio
+
+void setup_hcal_daq(pflib::lpGBT& lpgbt) {
+  setup_hcal_daq_gpio(lpgbt);
+  lpgbt.gpio_set(0, true);
+  lpgbt.gpio_set(1, true);
+  lpgbt.gpio_set(2, true);
+  lpgbt.gpio_set(4, true);
+  lpgbt.gpio_set(8, true);
   lpgbt.gpio_set(11, true);
 
   // setup clocks
@@ -62,39 +67,45 @@ void setup_hcal_daq(pflib::lpGBT& lpgbt) {
   lpgbt.finalize_setup();
 }
 
-void setup_hcal_trig(pflib::lpGBT& lpgbt) {
+void setup_hcal_trig_gpio(pflib::lpGBT& lpgbt) {
   // setup the reset lines
   lpgbt.gpio_cfg_set(
       2, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "BOARD_I2C_RST");
-  lpgbt.gpio_set(2, true);
   lpgbt.gpio_cfg_set(
       4, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "HGCROC0_HRST");
-  lpgbt.gpio_set(4, true);
   lpgbt.gpio_cfg_set(
       7, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "HGCROC0_SRST");
-  lpgbt.gpio_set(7, true);
   lpgbt.gpio_cfg_set(
       6, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "HGCROC3_HRST");
-  lpgbt.gpio_set(6, true);
   lpgbt.gpio_cfg_set(
       3, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "HGCROC3_SRST");
-  lpgbt.gpio_set(3, true);
   lpgbt.gpio_cfg_set(
       9, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "BIAS_I2C_RST");
-  lpgbt.gpio_set(9, true);
   lpgbt.gpio_cfg_set(
       8, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "ECON_HRST");
-  lpgbt.gpio_set(8, true);
+
   lpgbt.gpio_cfg_set(
       11, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
       "ECON_SRST");
+
+}  // end of setup_hcal_trig_gpio
+void setup_hcal_trig(pflib::lpGBT& lpgbt) {
+  setup_hcal_trig_gpio(lpgbt);
+
+  lpgbt.gpio_set(2, true);
+  lpgbt.gpio_set(3, true);
+  lpgbt.gpio_set(4, true);
+  lpgbt.gpio_set(6, true);
+  lpgbt.gpio_set(7, true);
+  lpgbt.gpio_set(8, true);
+  lpgbt.gpio_set(9, true);
   lpgbt.gpio_set(11, true);
 
   // setup the high speed inputs
@@ -109,32 +120,34 @@ void setup_erxtraining(pflib::lpGBT&, bool prbs_on) {
   /// TODO setup eRx for training mode
 }
 
+void setup_ecal_daq_gpio(pflib::lpGBT& lpgbt) {
+  lpgbt.gpio_cfg_set(
+      4,
+      lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLDOWN | lpGBT::GPIO_IS_STRONG,
+      "M0_POWER_EN");
+  lpgbt.gpio_cfg_set(
+      5, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
+      "M0_ROC_RE_Hb");
+  lpgbt.gpio_cfg_set(
+      6, lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
+      "M0_ROC_RE_Sb");
+  lpgbt.gpio_cfg_set(
+      7,
+      lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLDOWN | lpGBT::GPIO_IS_STRONG,
+      "M0_ECON_RE_Hb");
+  lpgbt.gpio_cfg_set(
+      8,
+      lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLDOWN | lpGBT::GPIO_IS_STRONG,
+      "M0_ECON_RE_Sb");
+}  // end of setup_ecal_daq_gpio
+
 void setup_ecal(pflib::lpGBT& lpgbt, ECAL_lpGBT_Config mode) {
+  setup_ecal_daq_gpio(lpgbt);
   if (mode == ECAL_lpGBT_Config::DAQ_SingleModuleMotherboard) {
-    lpgbt.gpio_cfg_set(
-        4,
-        lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLDOWN | lpGBT::GPIO_IS_STRONG,
-        "M0_POWER_EN");
     lpgbt.gpio_set(4, true);
-    lpgbt.gpio_cfg_set(
-        5,
-        lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
-        "M0_ROC_RE_Hb");
     lpgbt.gpio_set(5, true);
-    lpgbt.gpio_cfg_set(
-        6,
-        lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLUP | lpGBT::GPIO_IS_STRONG,
-        "M0_ROC_RE_Sb");
     lpgbt.gpio_set(6, true);
-    lpgbt.gpio_cfg_set(
-        7,
-        lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLDOWN | lpGBT::GPIO_IS_STRONG,
-        "M0_ECON_RE_Hb");
     lpgbt.gpio_set(7, true);
-    lpgbt.gpio_cfg_set(
-        8,
-        lpGBT::GPIO_IS_OUTPUT | lpGBT::GPIO_IS_PULLDOWN | lpGBT::GPIO_IS_STRONG,
-        "M0_ECON_RE_Sb");
     lpgbt.gpio_set(8, true);
 
     /*
@@ -157,7 +170,8 @@ void setup_ecal(pflib::lpGBT& lpgbt, ECAL_lpGBT_Config mode) {
 
     // finalize the setup
     lpgbt.finalize_setup();
-  }
+  }  // end condition on DAQ_SingleModuleMotherboard
+
   if (mode == ECAL_lpGBT_Config::TRIG_SingleModuleMotherboard) {
     // setup the high speed inputs
     for (int i = 0; i < 6; i++) {
@@ -165,8 +179,8 @@ void setup_ecal(pflib::lpGBT& lpgbt, ECAL_lpGBT_Config mode) {
     }
     // finalize the setup
     lpgbt.finalize_setup();
-  }
-}
+  }  // end condition on TRIG_SingleModuleMotherboard
+}  // end of setup_ecal
 
 }  // namespace standard_config
 }  // namespace lpgbt


### PR DESCRIPTION
Another (safer) approach to https://github.com/LDMX-Software/pflib/issues/315 as opposed to https://github.com/LDMX-Software/pflib/issues/315 where the GPIO happens in the setup now it happens standalone