### PR TITLE
Add workflow_run trigger for clang-format completion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: test
 
 on:
   push:
+  workflow_run:
+    workflows: ["clang-format"]
+    types:
+      - completed
 
 jobs:
   test:


### PR DESCRIPTION
The tests are run when somebody pushes, but when the bot pushes the clang format changes, it's not triggered. 
With this PR we trigger the compile tests only after the clang format CI finished