### PR TITLE
Fix  HT_EBO, data underflow for no data

### DIFF
--- a/src/pflib/packing/ECONDEventPacket.cxx
+++ b/src/pflib/packing/ECONDEventPacket.cxx
@@ -283,7 +283,7 @@ void ECONDEventPacket::from(std::span<uint32_t> data) {
   uint32_t hamming = (data[0] & mask<6>);
   pflib_log(trace) << "    P=" << passthrough << " E=" << expected;
 
-  pflib_log(trace) << "Econd header two: " << hex(data[1]);
+  pflib_log(trace) << "econd header two: " << hex(data[1]);
   // BX on bits 31-20
   uint32_t bx = ((data[1] >> 20) & mask<12>);
   // L1A on bits 19-14


### PR DESCRIPTION
There is two real things (+ internal documentation) in this PR:
 
I down the rabbit hole about what these packets mean, but Fig 33 is great!!
<img width="977" height="545" alt="Screenshot 2025-12-12 at 00 00 53" src="https://github.com/user-attachments/assets/fee1e0bc-b5a2-4c94-a19b-d188b9e19b59" />

So based on that I found that 
* `ht_ebo` is on 4 bits, not 5 so we need to do
```
uint32_t ht_ebo = ((data[0] >> 8) & mask<5>);
```
to
```
uint32_t ht_ebo = ((data[0] >> 8) & mask<4>);
```

And then I copy pasted a bunch of text from the document so the next person doesnt have to figure all this out.

EDIT: Some testing gave me 
```
warn: Incomplete event packet, stored payload length 1 is larger than the packet length 18446744073709551614
```
which is uint(0-2), so the last commit now adds +2 on the other side and then the printouts let the users do "math"