### PR TITLE
Patches from EcalSMM on Bittware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,8 @@ set(pflib_src
   src/pflib/zcu/HcalBackplane.cxx
   src/pflib/zcu/EcalSMM.cxx
   src/pflib/zcu/HGCROCBoardFiberless.cxx
-  src/pflib/Ecal.cxx
+  src/pflib/EcalModule.cxx
+  src/pflib/EcalSingleModuleMotherboard.cxx
   src/pflib/Bias.cxx
 )
 

--- a/app/tool/econ.cxx
+++ b/app/tool/econ.cxx
@@ -116,8 +116,29 @@ static void econ_status(const std::string& cmd, Target* tgt) {
            econ.getValues(fctrl_base + offset, 1).at(0));
   }
 
+  /**
+   * The PUSM state names are copied from the online ECON-D/T manual
+   * https://econ-user-manual.docs.cern.ch/CommonBlocks/pusm/
+   *
+   * The numbering there is offset by one compared to the indices that
+   * we are reading out from the chip, but I think that makes sense.
+   */
+  static const std::array<const char*, 9> pusm_state_names = {
+    "RESET",
+    "IDLE",
+    "RESET_PLL",
+    "WAIT_PLL_LOCK",
+    "RESET_DLLS",
+    "WAIT_DLL_RESET_DONE",
+    "WAIT_DLL_LOCK",
+    "RESET_LOGIC_USING_DLL",
+    "READY"
+  }; 
+  int pusm_state = econ.getPUSMStateValue();
+  const char* pusm_state_name = ((pusm_state >= 0 and pusm_state < pusm_state_names.size()) ? pusm_state_names[pusm_state] : "???");
+
   printf(" %18s: %d\n", "PUSM Run Val", econ.getPUSMRunValue());
-  printf(" %18s: %d\n", "PUSM State Val", econ.getPUSMStateValue());
+  printf(" %18s: %d %s\n", "PUSM State Val", pusm_state, pusm_state_name);
   printf(" %18s: %d\n", "Run Mode", econ.isRunMode());
 }
 

--- a/app/tool/econ.cxx
+++ b/app/tool/econ.cxx
@@ -124,18 +124,16 @@ static void econ_status(const std::string& cmd, Target* tgt) {
    * we are reading out from the chip, but I think that makes sense.
    */
   static const std::array<const char*, 9> pusm_state_names = {
-    "RESET",
-    "IDLE",
-    "RESET_PLL",
-    "WAIT_PLL_LOCK",
-    "RESET_DLLS",
-    "WAIT_DLL_RESET_DONE",
-    "WAIT_DLL_LOCK",
-    "RESET_LOGIC_USING_DLL",
-    "READY"
-  }; 
+      "RESET",         "IDLE",
+      "RESET_PLL",     "WAIT_PLL_LOCK",
+      "RESET_DLLS",    "WAIT_DLL_RESET_DONE",
+      "WAIT_DLL_LOCK", "RESET_LOGIC_USING_DLL",
+      "READY"};
   int pusm_state = econ.getPUSMStateValue();
-  const char* pusm_state_name = ((pusm_state >= 0 and pusm_state < pusm_state_names.size()) ? pusm_state_names[pusm_state] : "???");
+  const char* pusm_state_name =
+      ((pusm_state >= 0 and pusm_state < pusm_state_names.size())
+           ? pusm_state_names[pusm_state]
+           : "???");
 
   printf(" %18s: %d\n", "PUSM Run Val", econ.getPUSMRunValue());
   printf(" %18s: %d %s\n", "PUSM State Val", pusm_state, pusm_state_name);

--- a/app/tool/tasks/setup/align_phase_word.cxx
+++ b/app/tool/tasks/setup/align_phase_word.cxx
@@ -205,19 +205,15 @@ void align_word(Target* tgt, pflib::ECON& econ, std::vector<int> channels,
   // FAST CONTROL - ENABLE THE BCR (ORBIT SYNC)
   tgt->fc().standard_setup();
 
-  // TODO: Read BX value of link reset rocd
-
-  // ------- Scan when the ECON takes snapshot -----
-  int start_val{1}, end_val{51};
-  /*
-  if (on_zcu) {
-    start_val = 1;  // 3490;  // near your orbit region of interest
-    end_val = 51;   // 3540;    // up to orbit rollover
-  } else {
-    start_val = 64 * 40 - 60;  // near your orbit region of interest
-    end_val = 64 * 40 - 1;     // up to orbit rollover
-  }
-  */
+  /**
+   * @note We have no idea which BX value the link reset rocd
+   * fast command is being sent on. If we could read this value
+   * from the firmware, that should allow us to guess at a smaller
+   * region in time to scan.
+   * For now, we just start at BX=1 and count up until we find the first
+   * match.
+   */
+  int start_val{1}, end_val{on_zcu ? 3540 : (64*40 - 1)};
 
   bool aligned{false};
   for (int snapshot_bx{start_val}; snapshot_bx < end_val; snapshot_bx++) {

--- a/app/tool/tasks/setup/align_phase_word.cxx
+++ b/app/tool/tasks/setup/align_phase_word.cxx
@@ -213,7 +213,7 @@ void align_word(Target* tgt, pflib::ECON& econ, std::vector<int> channels,
    * For now, we just start at BX=1 and count up until we find the first
    * match.
    */
-  int start_val{1}, end_val{on_zcu ? 3540 : (64*40 - 1)};
+  int start_val{1}, end_val{on_zcu ? 3540 : (64 * 40 - 1)};
 
   bool aligned{false};
   for (int snapshot_bx{start_val}; snapshot_bx < end_val; snapshot_bx++) {

--- a/config/pftool/ecal-smm-bittware.yaml
+++ b/config/pftool/ecal-smm-bittware.yaml
@@ -1,0 +1,3 @@
+target:
+  type: "EcalSMMBittware"
+  ilink: 0

--- a/include/pflib/EcalModule.h
+++ b/include/pflib/EcalModule.h
@@ -89,16 +89,4 @@ class EcalModule {
   static const std::vector<std::pair<int, int>> roc_to_erx_map_;
 };
 
-class EcalMotherboard {
- public:
-  EcalMotherboard() {}
-  /// create a module
-  void createModule(int imodule, lpGBT& lpGBT, int i2cbus);
-  /// get a module
-  EcalModule& module(int imodule);
-
- private:
-  std::vector<std::shared_ptr<EcalModule>> modules_;
-};
-
 }  // namespace pflib

--- a/include/pflib/EcalSingleModuleMotherboard.h
+++ b/include/pflib/EcalSingleModuleMotherboard.h
@@ -26,8 +26,9 @@ class EcalSingleModuleMotherboard : public Target {
    * This should be called after the optical links are
    * properly setup and used to create access to the lpGBTs.
    */
-  void init(lpGBT& daq_lpgbt, lpGBT& trg_lpgbt, int module_i2c_bus, int roc_mask);
-  virtual const std::vector<std::pair<int,int>>& getRocErxMapping() override;
+  void init(lpGBT& daq_lpgbt, lpGBT& trg_lpgbt, int module_i2c_bus,
+            int roc_mask);
+  virtual const std::vector<std::pair<int, int>>& getRocErxMapping() override;
   virtual int nrocs() override;
   virtual int necons() override;
   virtual bool have_roc(int iroc) const override;
@@ -40,7 +41,9 @@ class EcalSingleModuleMotherboard : public Target {
   virtual void softResetECON(int which = -1) override;
   virtual void hardResetROCs() override;
   virtual void hardResetECONs() override;
-  virtual void setup_run(int irun, Target::DaqFormat format, int contrib_id) override;
+  virtual void setup_run(int irun, Target::DaqFormat format,
+                         int contrib_id) override;
+
  protected:
   /// handle to the hexa-module that we are connected to
   std::shared_ptr<EcalModule> the_module_;
@@ -50,6 +53,6 @@ class EcalSingleModuleMotherboard : public Target {
   int contrib_id_;
 };
 
-}
+}  // namespace pflib
 
 #endif

--- a/include/pflib/EcalSingleModuleMotherboard.h
+++ b/include/pflib/EcalSingleModuleMotherboard.h
@@ -1,0 +1,55 @@
+#pragma once
+#ifndef PFLIB_ECALSINGLEMODULEMOTHERBOARD_H
+#define PFLIB_ECALSINGLEMODULEMOTHERBOARD_H
+
+#include "pflib/EcalModule.h"
+#include "pflib/Target.h"
+
+namespace pflib {
+
+/**
+ * a target for Ecal motherboards holding a single module
+ *
+ * common accessors and initialization procedures between
+ * the ZCU and Bittware targets
+ * Since there is just one module, the ROC/ECON
+ * accessors and resets are just forwarding calls to our
+ * held instance of an EcalModule.
+ */
+class EcalSingleModuleMotherboard : public Target {
+ public:
+  virtual ~EcalSingleModuleMotherboard() = default;
+  /**
+   * common initialization given the DAQ/TRG lpGBTs and
+   * a mask labeling which ROCs on the module are active
+   *
+   * This should be called after the optical links are
+   * properly setup and used to create access to the lpGBTs.
+   */
+  void init(lpGBT& daq_lpgbt, lpGBT& trg_lpgbt, int module_i2c_bus, int roc_mask);
+  virtual const std::vector<std::pair<int,int>>& getRocErxMapping() override;
+  virtual int nrocs() override;
+  virtual int necons() override;
+  virtual bool have_roc(int iroc) const override;
+  virtual bool have_econ(int iecon) const override;
+  virtual std::vector<int> roc_ids() const override;
+  virtual std::vector<int> econ_ids() const override;
+  virtual ROC& roc(int which) override;
+  virtual ECON& econ(int which) override;
+  virtual void softResetROC(int which) override;
+  virtual void softResetECON(int which = -1) override;
+  virtual void hardResetROCs() override;
+  virtual void hardResetECONs() override;
+  virtual void setup_run(int irun, Target::DaqFormat format, int contrib_id) override;
+ protected:
+  /// handle to the hexa-module that we are connected to
+  std::shared_ptr<EcalModule> the_module_;
+  /// the format we are using for DAQ
+  Target::DaqFormat format_;
+  /// the contributor ID for DAQ
+  int contrib_id_;
+};
+
+}
+
+#endif

--- a/include/pflib/packing/Hex.h
+++ b/include/pflib/packing/Hex.h
@@ -19,7 +19,7 @@ struct hex {
   friend inline std::ostream& operator<<(
       std::ostream& os, const pflib::packing::hex<WordType, HexWidth>& h) {
     os << "0x" << std::setfill('0') << std::setw(HexWidth) << std::hex
-       << h.word_ << std::dec << std::setfill(' ');
+       << static_cast<int>(h.word_) << std::dec << std::setfill(' ');
     return os;
   }
 };

--- a/src/pflib/EcalModule.cxx
+++ b/src/pflib/EcalModule.cxx
@@ -1,4 +1,4 @@
-#include "pflib/Ecal.h"
+#include "pflib/EcalModule.h"
 
 #include "pflib/lpgbt/I2C.h"
 #include "pflib/utility/string_format.h"

--- a/src/pflib/EcalSingleModuleMotherboard.cxx
+++ b/src/pflib/EcalSingleModuleMotherboard.cxx
@@ -1,0 +1,128 @@
+#include "pflib/EcalSingleModuleMotherboard.h"
+
+#include "pflib/lpgbt/lpGBT_standard_configs.h"
+
+namespace pflib {
+
+void EcalSingleModuleMotherboard::init(
+    lpGBT& daq_lpgbt, lpGBT& trg_lpgbt, int module_i2c_bus, int roc_mask
+  ) {
+  // Setup DAQ lpGBT
+  try {
+    int daq_pusm = daq_lpgbt.status();
+    pflib::lpgbt::standard_config::setup_ecal_daq_gpio(daq_lpgbt);
+
+    if (daq_pusm == 19) {
+      pflib_log(debug) << "DAQ lpGBT is PUSM READY (19)";
+    } else {
+      pflib_log(debug)
+          << "DAQ lpGBT is not ready, attempting standard config";
+      try {
+        pflib::lpgbt::standard_config::setup_ecal(
+            daq_lpgbt, pflib::lpgbt::standard_config::ECAL_lpGBT_Config::
+                            DAQ_SingleModuleMotherboard);
+      } catch (const pflib::Exception& e) {
+        pflib_log(warn) << "Failure to apply standard config [" << e.name()
+                        << "]: " << e.message();
+      }
+    }
+  } catch (const pflib::Exception& e) {
+    pflib_log(debug) << "unable to I2C transact with lpGBT, advising user to "
+                        "check Optical links";
+    pflib_log(warn) << "Failure to check DAQ lpGBT status [" << e.name()
+                    << "]: " << e.message();
+    pflib_log(warn) << "Go into OPTO and make sure the link is READY"
+                    << " and then re-open pftool.";
+  }
+
+  // Setup TRG lpGBT
+  try {
+    int trg_pusm = trg_lpgbt.status();
+    if (trg_pusm == 19) {
+      pflib_log(debug) << "TRG lpGBT is PUSM READY (19)";
+    } else {
+      pflib_log(debug)
+          << "TRG lpGBT is not ready, attempting standard config";
+      try {
+        // was the DAQ_SMM setup config on the ZCU
+        pflib::lpgbt::standard_config::setup_ecal(
+            trg_lpgbt, pflib::lpgbt::standard_config::ECAL_lpGBT_Config::
+                              TRIG_SingleModuleMotherboard);
+      } catch (const pflib::Exception& e) {
+        pflib_log(info) << "Not Critical Problem setting up TRIGGER lpGBT.";
+        pflib_log(info) << "Failure to apply standard config [" << e.name()
+                        << "]: " << e.message();
+      }
+    }
+  } catch (const pflib::Exception& e) {
+    pflib_log(info) << "(Not Critical) Failure to check TRG lpGBT status ["
+                    << e.name() << "]: " << e.message();
+  }
+
+  the_module_ = std::make_shared<EcalModule>(daq_lpgbt, module_i2c_bus, 0, roc_mask);
+}
+
+const std::vector<std::pair<int,int>>& EcalSingleModuleMotherboard::getRocErxMapping() {
+  return EcalModule::getRocErxMapping();
+}
+
+int EcalSingleModuleMotherboard::nrocs() {
+  return the_module_->nrocs();
+}
+
+int EcalSingleModuleMotherboard::necons() {
+  return the_module_->necons();
+}
+
+bool EcalSingleModuleMotherboard::have_roc(int iroc) const {
+  return the_module_->have_roc(iroc);
+}
+
+bool EcalSingleModuleMotherboard::have_econ(int iecon) const {
+  return the_module_->have_econ(iecon);
+}
+
+std::vector<int> EcalSingleModuleMotherboard::roc_ids() const {
+  return the_module_->roc_ids();
+}
+
+std::vector<int> EcalSingleModuleMotherboard::econ_ids() const {
+  return the_module_->econ_ids();
+}
+
+ROC& EcalSingleModuleMotherboard::roc(int which) {
+  return the_module_->roc(which);
+}
+
+ECON& EcalSingleModuleMotherboard::econ(int which) {
+  return the_module_->econ(which);
+}
+
+void EcalSingleModuleMotherboard::softResetROC(int which) {
+  /// the soft reset is applied to all ROCs on the board
+  return the_module_->softResetROC();
+}
+
+void EcalSingleModuleMotherboard::softResetECON(int which) {
+  /// the soft reset is applied to all ECONs on the board
+  return the_module_->softResetECON();
+}
+
+void EcalSingleModuleMotherboard::hardResetROCs() {
+  return the_module_->hardResetROCs();
+}
+
+void EcalSingleModuleMotherboard::hardResetECONs() {
+  return the_module_->hardResetECONs();
+}
+
+void EcalSingleModuleMotherboard::setup_run(int irun, Target::DaqFormat format, int contrib_id) {
+  format_ = format;
+  contrib_id_ = contrib_id;
+
+  // this reset and clear_run were not present in the EcalSMMBittware
+  daq().reset();
+  fc().clear_run();
+}
+
+}

--- a/src/pflib/EcalSingleModuleMotherboard.cxx
+++ b/src/pflib/EcalSingleModuleMotherboard.cxx
@@ -4,9 +4,8 @@
 
 namespace pflib {
 
-void EcalSingleModuleMotherboard::init(
-    lpGBT& daq_lpgbt, lpGBT& trg_lpgbt, int module_i2c_bus, int roc_mask
-  ) {
+void EcalSingleModuleMotherboard::init(lpGBT& daq_lpgbt, lpGBT& trg_lpgbt,
+                                       int module_i2c_bus, int roc_mask) {
   // Setup DAQ lpGBT
   try {
     int daq_pusm = daq_lpgbt.status();
@@ -15,12 +14,11 @@ void EcalSingleModuleMotherboard::init(
     if (daq_pusm == 19) {
       pflib_log(debug) << "DAQ lpGBT is PUSM READY (19)";
     } else {
-      pflib_log(debug)
-          << "DAQ lpGBT is not ready, attempting standard config";
+      pflib_log(debug) << "DAQ lpGBT is not ready, attempting standard config";
       try {
         pflib::lpgbt::standard_config::setup_ecal(
             daq_lpgbt, pflib::lpgbt::standard_config::ECAL_lpGBT_Config::
-                            DAQ_SingleModuleMotherboard);
+                           DAQ_SingleModuleMotherboard);
       } catch (const pflib::Exception& e) {
         pflib_log(warn) << "Failure to apply standard config [" << e.name()
                         << "]: " << e.message();
@@ -41,13 +39,12 @@ void EcalSingleModuleMotherboard::init(
     if (trg_pusm == 19) {
       pflib_log(debug) << "TRG lpGBT is PUSM READY (19)";
     } else {
-      pflib_log(debug)
-          << "TRG lpGBT is not ready, attempting standard config";
+      pflib_log(debug) << "TRG lpGBT is not ready, attempting standard config";
       try {
         // was the DAQ_SMM setup config on the ZCU
         pflib::lpgbt::standard_config::setup_ecal(
             trg_lpgbt, pflib::lpgbt::standard_config::ECAL_lpGBT_Config::
-                              TRIG_SingleModuleMotherboard);
+                           TRIG_SingleModuleMotherboard);
       } catch (const pflib::Exception& e) {
         pflib_log(info) << "Not Critical Problem setting up TRIGGER lpGBT.";
         pflib_log(info) << "Failure to apply standard config [" << e.name()
@@ -59,20 +56,18 @@ void EcalSingleModuleMotherboard::init(
                     << e.name() << "]: " << e.message();
   }
 
-  the_module_ = std::make_shared<EcalModule>(daq_lpgbt, module_i2c_bus, 0, roc_mask);
+  the_module_ =
+      std::make_shared<EcalModule>(daq_lpgbt, module_i2c_bus, 0, roc_mask);
 }
 
-const std::vector<std::pair<int,int>>& EcalSingleModuleMotherboard::getRocErxMapping() {
+const std::vector<std::pair<int, int>>&
+EcalSingleModuleMotherboard::getRocErxMapping() {
   return EcalModule::getRocErxMapping();
 }
 
-int EcalSingleModuleMotherboard::nrocs() {
-  return the_module_->nrocs();
-}
+int EcalSingleModuleMotherboard::nrocs() { return the_module_->nrocs(); }
 
-int EcalSingleModuleMotherboard::necons() {
-  return the_module_->necons();
-}
+int EcalSingleModuleMotherboard::necons() { return the_module_->necons(); }
 
 bool EcalSingleModuleMotherboard::have_roc(int iroc) const {
   return the_module_->have_roc(iroc);
@@ -116,7 +111,8 @@ void EcalSingleModuleMotherboard::hardResetECONs() {
   return the_module_->hardResetECONs();
 }
 
-void EcalSingleModuleMotherboard::setup_run(int irun, Target::DaqFormat format, int contrib_id) {
+void EcalSingleModuleMotherboard::setup_run(int irun, Target::DaqFormat format,
+                                            int contrib_id) {
   format_ = format;
   contrib_id_ = contrib_id;
 
@@ -125,4 +121,4 @@ void EcalSingleModuleMotherboard::setup_run(int irun, Target::DaqFormat format, 
   fc().clear_run();
 }
 
-}
+}  // namespace pflib

--- a/src/pflib/bittware/EcalSMM.cxx
+++ b/src/pflib/bittware/EcalSMM.cxx
@@ -13,6 +13,7 @@ static constexpr int I2C_BUS_M0 = 1;
 
 class EcalSMMTargetBW : public EcalSingleModuleMotherboard {
   mutable logging::logger the_log_{logging::get("EcalSMMBW")};
+
  public:
   EcalSMMTargetBW(int itarget, uint8_t roc_mask, const char* dev) {
     using namespace pflib::bittware;

--- a/src/pflib/bittware/EcalSMM.cxx
+++ b/src/pflib/bittware/EcalSMM.cxx
@@ -1,11 +1,8 @@
-#include "pflib/Ecal.h"
-#include "pflib/Target.h"
+#include "pflib/EcalSingleModuleMotherboard.h"
 #include "pflib/bittware/bittware_FastControl.h"
 #include "pflib/bittware/bittware_daq.h"
 #include "pflib/bittware/bittware_elinks.h"
 #include "pflib/bittware/bittware_optolink.h"
-#include "pflib/lpgbt/I2C.h"
-#include "pflib/lpgbt/lpGBT_standard_configs.h"
 #include "pflib/utility/string_format.h"
 
 namespace pflib {
@@ -14,9 +11,8 @@ static constexpr int ADDR_ECAL_SMM_DAQ = 0x78 | 0x04;
 static constexpr int ADDR_ECAL_SMM_TRIG = 0x78;
 static constexpr int I2C_BUS_M0 = 1;
 
-class EcalSMMTargetBW : public Target {
+class EcalSMMTargetBW : public EcalSingleModuleMotherboard {
   mutable logging::logger the_log_{logging::get("EcalSMMBW")};
-
  public:
   EcalSMMTargetBW(int itarget, uint8_t roc_mask, const char* dev) {
     using namespace pflib::bittware;
@@ -31,99 +27,19 @@ class EcalSMMTargetBW : public Target {
     trig_lpgbt_ =
         std::make_unique<pflib::lpGBT>(opto_["TRG"]->lpgbt_transport());
 
-    ecalModule_ = std::make_shared<pflib::EcalModule>(*daq_lpgbt_, I2C_BUS_M0,
-                                                      0, roc_mask);
+    init(*daq_lpgbt_, *trig_lpgbt_, I2C_BUS_M0, roc_mask);
 
     elinks_ = std::make_unique<OptoElinksBW>(itarget, dev);
     daq_ = std::make_unique<bittware::HcalBackplaneBW_Capture>(dev);
 
-    // Setup DAQ lpGBT
-    try {
-      int daq_pusm = daq_lpgbt_->status();
-      pflib::lpgbt::standard_config::setup_ecal_daq_gpio(*daq_lpgbt_);
-
-      if (daq_pusm == 19) {
-        pflib_log(debug) << "DAQ lpGBT is PUSM READY (19)";
-      } else {
-        pflib_log(debug)
-            << "DAQ lpGBT is not ready, attempting standard config";
-        try {
-          pflib::lpgbt::standard_config::setup_ecal(
-              *daq_lpgbt_, pflib::lpgbt::standard_config::ECAL_lpGBT_Config::
-                               DAQ_SingleModuleMotherboard);
-        } catch (const pflib::Exception& e) {
-          pflib_log(warn) << "Failure to apply standard config [" << e.name()
-                          << "]: " << e.message();
-        }
-      }
-    } catch (const pflib::Exception& e) {
-      pflib_log(debug) << "unable to I2C transact with lpGBT, advising user to "
-                          "check Optical links";
-      pflib_log(warn) << "Failure to check DAQ lpGBT status [" << e.name()
-                      << "]: " << e.message();
-      pflib_log(warn) << "Go into OPTO and make sure the link is READY"
-                      << " and then re-open pftool.";
-    }
-
-    // Setup TRG lpGBT
-    try {
-      int trg_pusm = trig_lpgbt_->status();
-      if (trg_pusm == 19) {
-        pflib_log(debug) << "TRG lpGBT is PUSM READY (19)";
-      } else {
-        pflib_log(debug)
-            << "TRG lpGBT is not ready, attempting standard config";
-        try {
-          pflib::lpgbt::standard_config::setup_ecal(
-              *trig_lpgbt_, pflib::lpgbt::standard_config::ECAL_lpGBT_Config::
-                                TRIG_SingleModuleMotherboard);
-        } catch (const pflib::Exception& e) {
-          pflib_log(info) << "Not Critical Problem setting up TRIGGER lpGBT.";
-          pflib_log(info) << "Failure to apply standard config [" << e.name()
-                          << "]: " << e.message();
-        }
-      }
-    } catch (const pflib::Exception& e) {
-      pflib_log(info) << "(Not Critical) Failure to check TRG lpGBT status ["
-                      << e.name() << "]: " << e.message();
-    }
-
     fc_ = std::make_shared<bittware::BWFastControl>(dev);
   }
-
-  const std::vector<std::pair<int, int>>& getRocErxMapping() override;
-  virtual int nrocs() { return ecalModule_->nrocs(); }
-  virtual int necons() { return ecalModule_->necons(); }
-  virtual bool have_roc(int iroc) const { return ecalModule_->have_roc(iroc); }
-  virtual bool have_econ(int iecon) const {
-    return ecalModule_->have_econ(iecon);
-  }
-  virtual std::vector<int> roc_ids() const { return ecalModule_->roc_ids(); }
-  virtual std::vector<int> econ_ids() const { return ecalModule_->econ_ids(); }
-
-  virtual ROC& roc(int which) { return ecalModule_->roc(which); }
-  virtual ECON& econ(int which) { return ecalModule_->econ(which); }
-
-  virtual void softResetROC(int which) override { ecalModule_->softResetROC(); }
-
-  virtual void softResetECON(int which = -1) override {
-    ecalModule_->softResetECON();
-  }
-
-  virtual void hardResetROCs() override { ecalModule_->hardResetROCs(); }
-
-  virtual void hardResetECONs() override { ecalModule_->hardResetECONs(); }
 
   virtual Elinks& elinks() override { return *elinks_; }
 
   virtual DAQ& daq() override { return *daq_; }
 
   virtual FastControl& fc() override { return *fc_; }
-
-  virtual void setup_run(int irun, Target::DaqFormat format, int contrib_id) {
-    format_ = format;
-    contrib_id_ = contrib_id;
-  }
 
   virtual std::vector<uint32_t> read_event() override {
     if (format_ == Target::DaqFormat::ECOND_SW_HEADERS) {
@@ -137,22 +53,15 @@ class EcalSMMTargetBW : public Target {
   }
 
  private:
-  std::shared_ptr<EcalModule> ecalModule_;
   std::unique_ptr<lpGBT> daq_lpgbt_, trig_lpgbt_;
   std::unique_ptr<pflib::bittware::OptoElinksBW> elinks_;
   std::unique_ptr<bittware::HcalBackplaneBW_Capture> daq_;
   std::shared_ptr<pflib::bittware::BWFastControl> fc_;
-  Target::DaqFormat format_;
-  int contrib_id_;
 };
 
 Target* makeTargetEcalSMMBittware(int ilink, uint8_t roc_mask,
                                   const char* dev) {
   return new EcalSMMTargetBW(ilink, roc_mask, dev);
-}
-
-const std::vector<std::pair<int, int>>& EcalSMMTargetBW::getRocErxMapping() {
-  return EcalModule::getRocErxMapping();
 }
 
 }  // namespace pflib

--- a/src/pflib/zcu/EcalSMM.cxx
+++ b/src/pflib/zcu/EcalSMM.cxx
@@ -29,8 +29,8 @@ class EcalSMMTargetZCU : public EcalSingleModuleMotherboard {
 
     init(*daq_lpgbt_, *trig_lpgbt_, I2C_BUS_M0, roc_mask);
 
-    elinks_ = std::make_unique<OptoElinksZCU>(daq_lpgbt_.get(), trig_lpgbt_.get(),
-                                              itarget);
+    elinks_ = std::make_unique<OptoElinksZCU>(daq_lpgbt_.get(),
+                                              trig_lpgbt_.get(), itarget);
     daq_ = std::make_unique<ZCU_Capture>();
 
     fc_ = std::shared_ptr<FastControl>(make_FastControlCMS_MMap());

--- a/src/pflib/zcu/EcalSMM.cxx
+++ b/src/pflib/zcu/EcalSMM.cxx
@@ -1,5 +1,4 @@
-#include "pflib/Ecal.h"
-#include "pflib/Target.h"
+#include "pflib/EcalSingleModuleMotherboard.h"
 #include "pflib/lpgbt/lpGBT_standard_configs.h"
 #include "pflib/utility/string_format.h"
 #include "pflib/zcu/zcu_daq.h"
@@ -10,7 +9,7 @@ namespace pflib {
 
 static constexpr int I2C_BUS_M0 = 1;
 
-class EcalSMMTargetZCU : public Target {
+class EcalSMMTargetZCU : public EcalSingleModuleMotherboard {
  public:
   EcalSMMTargetZCU(int itarget, uint8_t roc_mask) {
     using namespace pflib::zcu;
@@ -28,104 +27,20 @@ class EcalSMMTargetZCU : public Target {
     trig_lpgbt_ =
         std::make_unique<pflib::lpGBT>(opto_["TRG"]->lpgbt_transport());
 
-    // Setup DAQ lpGBT
-    try {
-      int daq_pusm = daq_lpgbt_->status();
-      pflib::lpgbt::standard_config::setup_ecal_daq_gpio(*daq_lpgbt_);
+    init(*daq_lpgbt_, *trig_lpgbt_, I2C_BUS_M0, roc_mask);
 
-      if (daq_pusm == 19) {
-        pflib_log(debug) << "DAQ lpGBT is PUSM READY (19)";
-      } else {
-        pflib_log(debug)
-            << "DAQ lpGBT is not ready, attempting standard config";
-        try {
-          pflib::lpgbt::standard_config::setup_ecal(
-              *daq_lpgbt_, pflib::lpgbt::standard_config::ECAL_lpGBT_Config::
-                               DAQ_SingleModuleMotherboard);
-        } catch (const pflib::Exception& e) {
-          pflib_log(warn) << "Failure to apply standard config [" << e.name()
-                          << "]: " << e.message();
-        }
-      }
-    } catch (const pflib::Exception& e) {
-      pflib_log(debug) << "unable to I2C transact with lpGBT, advising user to "
-                          "check Optical links";
-      pflib_log(warn) << "Failure to check DAQ lpGBT status [" << e.name()
-                      << "]: " << e.message();
-      pflib_log(warn) << "Go into OPTO and make sure the link is READY"
-                      << " and then re-open pftool.";
-    }
-
-    // Setup TRG lpGBT
-    try {
-      int trg_pusm = trig_lpgbt_->status();
-      if (trg_pusm == 19) {
-        pflib_log(debug) << "TRG lpGBT is PUSM READY (19)";
-      } else {
-        pflib_log(debug)
-            << "TRG lpGBT is not ready, attempting standard config";
-        try {
-          pflib::lpgbt::standard_config::setup_ecal(
-              *trig_lpgbt_, pflib::lpgbt::standard_config::ECAL_lpGBT_Config::
-                                DAQ_SingleModuleMotherboard);
-        } catch (const pflib::Exception& e) {
-          pflib_log(info) << "Not Critical Problem setting up TRIGGER lpGBT.";
-          pflib_log(info) << "Failure to apply standard config [" << e.name()
-                          << "]: " << e.message();
-        }
-      }
-    } catch (const pflib::Exception& e) {
-      pflib_log(info) << "(Not Critical) Failure to check TRG lpGBT status ["
-                      << e.name() << "]: " << e.message();
-    }
-
-    ecalModule_ = std::make_shared<pflib::EcalModule>(*daq_lpgbt_, I2C_BUS_M0,
-                                                      0, roc_mask);
-
-    elinks_ = std::make_unique<OptoElinksZCU>(&(*daq_lpgbt_), &(*trig_lpgbt_),
+    elinks_ = std::make_unique<OptoElinksZCU>(daq_lpgbt_.get(), trig_lpgbt_.get(),
                                               itarget);
     daq_ = std::make_unique<ZCU_Capture>();
 
     fc_ = std::shared_ptr<FastControl>(make_FastControlCMS_MMap());
   }
 
-  const std::vector<std::pair<int, int>>& getRocErxMapping() override;
-
-  virtual int nrocs() { return ecalModule_->nrocs(); }
-  virtual int necons() { return ecalModule_->necons(); }
-  virtual bool have_roc(int iroc) const { return ecalModule_->have_roc(iroc); }
-  virtual bool have_econ(int iecon) const {
-    return ecalModule_->have_econ(iecon);
-  }
-  virtual std::vector<int> roc_ids() const { return ecalModule_->roc_ids(); }
-  virtual std::vector<int> econ_ids() const { return ecalModule_->econ_ids(); }
-
-  virtual ROC& roc(int which) { return ecalModule_->roc(which); }
-  virtual ECON& econ(int which) { return ecalModule_->econ(which); }
-
-  virtual void softResetROC(int which) override { ecalModule_->softResetROC(); }
-
-  virtual void softResetECON(int which = -1) override {
-    ecalModule_->softResetECON();
-  }
-
-  virtual void hardResetROCs() override { ecalModule_->hardResetROCs(); }
-
-  virtual void hardResetECONs() override { ecalModule_->hardResetECONs(); }
-
   virtual Elinks& elinks() override { return *elinks_; }
 
   virtual DAQ& daq() override { return *daq_; }
 
   virtual FastControl& fc() override { return *fc_; }
-
-  virtual void setup_run(int irun, Target::DaqFormat format, int contrib_id) {
-    format_ = format;
-    contrib_id_ = contrib_id;
-
-    daq().reset();
-    fc().clear_run();
-  }
 
   virtual std::vector<uint32_t> read_event() override {
     if (format_ == Target::DaqFormat::ECOND_SW_HEADERS) {
@@ -139,18 +54,11 @@ class EcalSMMTargetZCU : public Target {
   }
 
  private:
-  std::shared_ptr<EcalModule> ecalModule_;
   std::unique_ptr<lpGBT> daq_lpgbt_, trig_lpgbt_;
   std::unique_ptr<pflib::zcu::OptoElinksZCU> elinks_;
   std::unique_ptr<pflib::zcu::ZCU_Capture> daq_;
   std::shared_ptr<pflib::FastControl> fc_;
-  Target::DaqFormat format_;
-  int contrib_id_;
 };
-
-const std::vector<std::pair<int, int>>& EcalSMMTargetZCU::getRocErxMapping() {
-  return EcalModule::getRocErxMapping();
-}
 
 Target* makeTargetEcalSMMZCU(int ilink, uint8_t roc_mask) {
   return new EcalSMMTargetZCU(ilink, roc_mask);


### PR DESCRIPTION
Just having this PR open so folks know where I'm pushing developments while working on this and to have a place to keep any notes on progress out in the open.

Right now, I have not been able to get the driver to load on the machine hosting the Bittware, so I'm blocked by that issue (unrelated to pflib). I'm hopeful that, since the HcalBackplane move from ZCU to Bittware went pretty smooth, that the EcalSMM will as well. :crossed_fingers: also hoping I didn't just jinx it :crossed_fingers: 

- add state names for ECON PUSM
- add config for a single EcalSMM Bittware teststand
