### PR TITLE
 Fix inv_vref_scan_lund bug

### DIFF
--- a/app/tool/algorithm/inv_vref_lund.cxx
+++ b/app/tool/algorithm/inv_vref_lund.cxx
@@ -37,8 +37,8 @@ void DataFitter::sort_and_append(std::vector<int>& inv_vrefs,
                 (inv_vrefs[i] - inv_vrefs[i + 1]);
 
     // Threshold check. CMS uses 0.05. This value fits with my analysis as well.
-    if (std::abs(LH) < flat_threshold ||
-        std::abs(RH) < flat_threshold) {  // flat regime
+    if (std::abs(LH) <= flat_threshold ||
+        std::abs(RH) <= flat_threshold) {  // flat regime
       nonlinear_.push_back({inv_vrefs[i], pedestals[i], LH, RH});
     } else {  // we're in a linear regime or there's outliers
       double LH_err =

--- a/app/tool/algorithm/inv_vref_lund.cxx
+++ b/app/tool/algorithm/inv_vref_lund.cxx
@@ -114,7 +114,7 @@ int DataFitter::fit(int target) {
 std::map<std::string, std::map<std::string, uint64_t>> inv_vref_lund(
     Target* tgt, ROC& roc) {
   static auto the_log_{::pflib::logging::get("inv_vref_scan")};
-  int nevents = pftool::readline_int("Number of events per point: ", 1);
+  int nevents = pftool::readline_int("Number of events per point: ", 100);
   // TODO 348
   std::array<int, 2> channels = {17, 51};
 

--- a/app/tool/algorithm/inv_vref_lund.h
+++ b/app/tool/algorithm/inv_vref_lund.h
@@ -36,9 +36,9 @@ class DataFitter {
   };
   std::vector<Point> linear_;
   std::vector<Point> nonlinear_;
-  int LH_median_;
+  double LH_median_;
   double LH_std_median_;
-  int RH_median_;
+  double RH_median_;
 };
 
 /**


### PR DESCRIPTION
- Fixed a bug that caused no points to pass the linear region filter and resulting in an attempt to fit an empty vector
- Fixed a bug that didn't exclude points with flat slopes