### PR TITLE
uncompress 10bit ToT into its 12bit measurement

### DIFF
--- a/include/pflib/Exception.h
+++ b/include/pflib/Exception.h
@@ -26,8 +26,8 @@ class Exception : public std::exception {
    * @param line Line in the source code where the exception occurred.
    * @param function Function in which the exception occurred.
    */
-  Exception(const std::string &name, const std::string &message,
-            const std::string &module, int line, const std::string &function)
+  Exception(const std::string& name, const std::string& message,
+            const std::string& module, int line, const std::string& function)
       : name_{name},
         message_{message},
         module_{module},
@@ -43,25 +43,25 @@ class Exception : public std::exception {
    * Get the name of the exception.
    * @return The name of the exception.
    */
-  const std::string &name() const throw() { return name_; }
+  const std::string& name() const throw() { return name_; }
 
   /**
    * Get the message of the exception.
    * @return The message of the exception.
    */
-  const std::string &message() const throw() { return message_; }
+  const std::string& message() const throw() { return message_; }
 
   /**
    * Get the source filename where the exception occurred.
    * @return The source filename where the exception occurred.
    */
-  const std::string &module() const throw() { return module_; }
+  const std::string& module() const throw() { return module_; }
 
   /**
    * Get the function name where the exception occurred.
    * @return The function name where the exception occurred.
    */
-  const std::string &function() const throw() { return function_; }
+  const std::string& function() const throw() { return function_; }
 
   /**
    * Get the source line number where the exception occurred.
@@ -73,7 +73,7 @@ class Exception : public std::exception {
    * The error message.
    * @return The error message.
    */
-  virtual const char *what() const throw() { return message_.c_str(); }
+  virtual const char* what() const throw() { return message_.c_str(); }
 
  private:
   /** Exception name. */

--- a/src/pflib/packing/ECONDEventPacket.cxx
+++ b/src/pflib/packing/ECONDEventPacket.cxx
@@ -11,7 +11,7 @@
 namespace pflib::packing {
 
 std::size_t ECONDEventPacket::unpack_link_subpacket(std::span<uint32_t> data,
-                                                    DAQLinkFrame &link,
+                                                    DAQLinkFrame& link,
                                                     bool passthrough) {
   pflib_log(trace) << "link header " << hex(data[0]);
   // sub-packet start
@@ -56,7 +56,7 @@ std::size_t ECONDEventPacket::unpack_link_subpacket(std::span<uint32_t> data,
                      << " i_ch=" << i_chan;
 
     // deduce a reference to the channel that we are unpacking
-    Sample *ch = &(link.calib);
+    Sample* ch = &(link.calib);
     if (i_chan < 18) {
       ch = &(link.channels[i_chan]);
     } else if (i_chan > 18) {
@@ -327,7 +327,7 @@ void ECONDEventPacket::from(std::span<uint32_t> data) {
   }
 
   std::size_t offset{2};
-  for (auto &link : links) {
+  for (auto& link : links) {
     offset += unpack_link_subpacket(data.subspan(offset), link, passthrough);
     link.bx = bx;
     link.event = l1a;

--- a/src/pflib/packing/Sample.cxx
+++ b/src/pflib/packing/Sample.cxx
@@ -30,7 +30,14 @@ int Sample::adc() const {
 
 int Sample::tot() const {
   if (Tc()) {
-    return ((this->word >> 10) & mask<10>);
+    // the HGCROC compresses a 12bit ToT measurement to 10bits
+    int compressed = ((this->word >> 10) & mask<10>);
+    // if the highest bit is set, then shift the lower 9 by three
+    if (compressed & 0b1000000000) {
+      return ((compressed & mask<9>) << 3);
+    } else {
+      return compressed;
+    }
   } else {
     return -1;
   }

--- a/test/decoding.cxx
+++ b/test/decoding.cxx
@@ -140,6 +140,17 @@ BOOST_AUTO_TEST_CASE(tot_output) {
   BOOST_CHECK(s.toa() == 3);
 }
 
+BOOST_AUTO_TEST_CASE(high_tot) {
+  pflib::packing::Sample s;
+  s.word = 0b11000000000110000000100000000011;
+  BOOST_CHECK(s.Tc() == true);
+  BOOST_CHECK(s.Tp() == true);
+  BOOST_CHECK(s.adc() == -1);
+  BOOST_CHECK(s.tot() == 16);
+  BOOST_CHECK(s.adc_tm1() == 1);
+  BOOST_CHECK(s.toa() == 3);
+}
+
 BOOST_AUTO_TEST_CASE(tot_busy) {
   pflib::packing::Sample s;
   s.word = 0b01000000000100000000100000000011;
@@ -484,13 +495,15 @@ BOOST_AUTO_TEST_CASE(econd_spec_example_fig33) {
   BOOST_CHECK_EQUAL(-1, ep.links[0].channels[26].adc_tm1());
   BOOST_CHECK_EQUAL(ch4_adc, ep.links[0].channels[26].adc());
   BOOST_CHECK_EQUAL(ch4_toa, ep.links[0].channels[26].toa());
-  BOOST_CHECK_EQUAL(ch4_tot, ep.links[0].channels[26].tot());
+  // HGCROC does 12bit compression that we need to decompress
+  BOOST_CHECK_EQUAL(((ch4_tot & mask<9>) << 3), ep.links[0].channels[26].tot());
 
   BOOST_TEST_INFO("Checking transmitted channel 5 (should be CH 29)");
   BOOST_CHECK_EQUAL(ch5_adctm1, ep.links[0].channels[29].adc_tm1());
   BOOST_CHECK_EQUAL(-1, ep.links[0].channels[29].adc());
   BOOST_CHECK_EQUAL(ch5_toa, ep.links[0].channels[29].toa());
-  BOOST_CHECK_EQUAL(ch5_tot, ep.links[0].channels[29].tot());
+  // HGCROC does 12bit compression that we need to decompress
+  BOOST_CHECK_EQUAL(((ch5_tot & mask<9>) << 3), ep.links[0].channels[29].tot());
 
   BOOST_TEST_INFO("Checking transmitted channel 6 (should be CH 31)");
   BOOST_CHECK_EQUAL(ch6_adctm1, ep.links[0].channels[31].adc_tm1());

--- a/test/decoding.cxx
+++ b/test/decoding.cxx
@@ -142,11 +142,11 @@ BOOST_AUTO_TEST_CASE(tot_output) {
 
 BOOST_AUTO_TEST_CASE(high_tot) {
   pflib::packing::Sample s;
-  s.word = 0b11000000000110000000100000000011;
+  s.word = 0b11000000000111000000100000000011;
   BOOST_CHECK(s.Tc() == true);
   BOOST_CHECK(s.Tp() == true);
   BOOST_CHECK(s.adc() == -1);
-  BOOST_CHECK(s.tot() == 16);
+  BOOST_CHECK(s.tot() == 2064);
   BOOST_CHECK(s.adc_tm1() == 1);
   BOOST_CHECK(s.toa() == 3);
 }


### PR DESCRIPTION
This resolves #427 and updates the decoding tests to ensure that we do this decompression when using `Sample::tot`