### PR TITLE
Trim_toa and Toa_vref updated to run on multiple ROCS (Toa_vref updates taken from Will's work)

### DIFF
--- a/app/tool/algorithm/get_toa_efficiencies.cxx
+++ b/app/tool/algorithm/get_toa_efficiencies.cxx
@@ -1,27 +1,57 @@
 #include "get_toa_efficiencies.h"
-
 #include "pflib/utility/efficiency.h"
-
+#include "pflib/logging/Logging.h"
 namespace pflib::algorithm {
 
 std::array<double, 72> get_toa_efficiencies(
+
+    int i_roc,
+    const pflib::packing::SingleECONDRocErxMapping& mapping,
     const std::vector<pflib::packing::MultiSampleECONDEventPacket>& data) {
+
+  static auto the_log_{::pflib::logging::get("get_toa_efficiencies")};
   std::array<double, 72> efficiencies;
+
   /// reserve a vector of the appropriate size to avoid repeating allocation
   /// time for all 72 channels
+
+  if (data.empty()) {
+    pflib_log(warn) << "[DEBUG TOA] data packet vector is EMPTY for ROC " << i_roc;
+    efficiencies.fill(0.0);
+    return efficiencies;
+  }
+
   std::vector<int> toas(data.size());
   for (int ch{0}; ch < 72; ch++) {
     // TODO: 348
-    int i_link = (ch / 36);
-    int i_ch = ch % 36;
+    auto [i_erx, i_ch] = mapping.toErxChannel(i_roc, ch);
+    if (i_erx < 0 || i_ch < 0) {
+      pflib_log(error) << "[DEBUG MAP] Sanity Failure: Negative mapping values detected "
+                       << "ROC " << i_roc << " Ch " << ch
+                       << " resolved to eRx = " << (int)i_erx << ", eCh = " << (int) i_ch;
+    }
+
     for (std::size_t i{0}; i < toas.size(); i++) {
-      toas[i] = data[i].samples[data[i].i_soi].channel(i_link, i_ch).toa();
+      toas[i] = data[i].soi().channel(i_erx, i_ch).toa();
     }
     /// we assume that the data provided is not empty otherwise the efficiency
     /// calculation is meaningless
+
+    if (ch == 0 || ch == 36) {
+      pflib_log(trace) << "[DEBUG TOA] ROC " << i_roc << " Ch " << ch
+                       << " (eRx: " << (int)i_erx << ", eCh: " << (int)i_ch << ")"
+                       << " first 3 raw TOAs: [" << toas[0] << ", "
+                       << (toas.size() > 1 ? std::to_string(toas[1]) : "N/A") << ", "
+                       << (toas.size() > 2 ? std::to_string(toas[2]) : "N/A") << "]";
+    }
     efficiencies[ch] = pflib::utility::efficiency(toas);
+    if (efficiencies[ch] > 0.0) {
+      pflib_log(debug) << "[DEBUG TOA] Found non-zero efficiency on ROC " << i_roc
+                       << " Ch " << ch << " = " << efficiencies[ch];
+    }
   }
   return efficiencies;
-}
 
+}
 }  // namespace pflib::algorithm
+

--- a/app/tool/algorithm/get_toa_efficiencies.cxx
+++ b/app/tool/algorithm/get_toa_efficiencies.cxx
@@ -1,14 +1,13 @@
 #include "get_toa_efficiencies.h"
-#include "pflib/utility/efficiency.h"
+
 #include "pflib/logging/Logging.h"
+#include "pflib/utility/efficiency.h"
 namespace pflib::algorithm {
 
 std::array<double, 72> get_toa_efficiencies(
 
-    int i_roc,
-    const pflib::packing::SingleECONDRocErxMapping& mapping,
+    int i_roc, const pflib::packing::SingleECONDRocErxMapping& mapping,
     const std::vector<pflib::packing::MultiSampleECONDEventPacket>& data) {
-
   static auto the_log_{::pflib::logging::get("get_toa_efficiencies")};
   std::array<double, 72> efficiencies;
 
@@ -16,7 +15,8 @@ std::array<double, 72> get_toa_efficiencies(
   /// time for all 72 channels
 
   if (data.empty()) {
-    pflib_log(warn) << "[DEBUG TOA] data packet vector is EMPTY for ROC " << i_roc;
+    pflib_log(warn) << "[DEBUG TOA] data packet vector is EMPTY for ROC "
+                    << i_roc;
     efficiencies.fill(0.0);
     return efficiencies;
   }
@@ -26,9 +26,10 @@ std::array<double, 72> get_toa_efficiencies(
     // TODO: 348
     auto [i_erx, i_ch] = mapping.toErxChannel(i_roc, ch);
     if (i_erx < 0 || i_ch < 0) {
-      pflib_log(error) << "[DEBUG MAP] Sanity Failure: Negative mapping values detected "
-                       << "ROC " << i_roc << " Ch " << ch
-                       << " resolved to eRx = " << (int)i_erx << ", eCh = " << (int) i_ch;
+      pflib_log(error)
+          << "[DEBUG MAP] Sanity Failure: Negative mapping values detected "
+          << "ROC " << i_roc << " Ch " << ch
+          << " resolved to eRx = " << (int)i_erx << ", eCh = " << (int)i_ch;
     }
 
     for (std::size_t i{0}; i < toas.size(); i++) {
@@ -39,19 +40,20 @@ std::array<double, 72> get_toa_efficiencies(
 
     if (ch == 0 || ch == 36) {
       pflib_log(trace) << "[DEBUG TOA] ROC " << i_roc << " Ch " << ch
-                       << " (eRx: " << (int)i_erx << ", eCh: " << (int)i_ch << ")"
+                       << " (eRx: " << (int)i_erx << ", eCh: " << (int)i_ch
+                       << ")"
                        << " first 3 raw TOAs: [" << toas[0] << ", "
-                       << (toas.size() > 1 ? std::to_string(toas[1]) : "N/A") << ", "
-                       << (toas.size() > 2 ? std::to_string(toas[2]) : "N/A") << "]";
+                       << (toas.size() > 1 ? std::to_string(toas[1]) : "N/A")
+                       << ", "
+                       << (toas.size() > 2 ? std::to_string(toas[2]) : "N/A")
+                       << "]";
     }
     efficiencies[ch] = pflib::utility::efficiency(toas);
     if (efficiencies[ch] > 0.0) {
-      pflib_log(debug) << "[DEBUG TOA] Found non-zero efficiency on ROC " << i_roc
-                       << " Ch " << ch << " = " << efficiencies[ch];
+      pflib_log(debug) << "[DEBUG TOA] Found non-zero efficiency on ROC "
+                       << i_roc << " Ch " << ch << " = " << efficiencies[ch];
     }
   }
   return efficiencies;
-
 }
 }  // namespace pflib::algorithm
-

--- a/app/tool/algorithm/get_toa_efficiencies.h
+++ b/app/tool/algorithm/get_toa_efficiencies.h
@@ -15,8 +15,7 @@ namespace pflib::algorithm {
 
 // templated to match any event packet type
 std::array<double, 72> get_toa_efficiencies(
-    int i_roc,
-    const pflib::packing::SingleECONDRocErxMapping& mapping,
+    int i_roc, const pflib::packing::SingleECONDRocErxMapping& mapping,
     const std::vector<pflib::packing::MultiSampleECONDEventPacket>& data);
 
 }  // namespace pflib::algorithm

--- a/app/tool/algorithm/get_toa_efficiencies.h
+++ b/app/tool/algorithm/get_toa_efficiencies.h
@@ -15,6 +15,8 @@ namespace pflib::algorithm {
 
 // templated to match any event packet type
 std::array<double, 72> get_toa_efficiencies(
+    int i_roc,
+    const pflib::packing::SingleECONDRocErxMapping& mapping,
     const std::vector<pflib::packing::MultiSampleECONDEventPacket>& data);
 
 }  // namespace pflib::algorithm

--- a/app/tool/algorithm/toa_vref_scan.cxx
+++ b/app/tool/algorithm/toa_vref_scan.cxx
@@ -1,4 +1,5 @@
 #include "toa_vref_scan.h"
+
 #include "../daq_run.h"
 #include "../tasks/toa_vref_scan.h"
 #include "get_toa_efficiencies.h"
@@ -6,11 +7,9 @@
 #include "pflib/utility/string_format.h"
 namespace pflib::algorithm {
 
-std::map<int, std::map<std::string, std::map<std::string, uint64_t>>> toa_vref_scan(
-    Target* tgt) {
+std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>
+toa_vref_scan(Target* tgt) {
   static auto the_log_{::pflib::logging::get("toa_vref_scan")};
-
-
 
   /// do a run of 100 samples per toa_vref to measure the TOA
   /// efficiency when looking at pedestal data
@@ -21,15 +20,12 @@ std::map<int, std::map<std::string, std::map<std::string, uint64_t>>> toa_vref_s
 
   std::map<int, std::array<int, 2>> target;  // i_roc int for each variable
   std::map<int, std::array<std::array<double, 256>, 2>> final_effs;
-  std::map<int, std::map<std::string, std::map<std::string, uint64_t>>> settings;
-
-
+  std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>
+      settings;
 
   // TODO 348
 
   DecodeAndBuffer buffer{n_events, tgt->nrocs() * 2};
-
-
 
   // loop over runs, from toa_vref = 0 to = 255
 
@@ -47,35 +43,35 @@ std::map<int, std::map<std::string, std::map<std::string, uint64_t>>> toa_vref_s
     pflib_log(trace) << "finished toa_vref = " << toa_vref
                      << ", getting efficiencies";
 
-
-
     for (int i_roc : tgt->roc_ids()) {
       // Debug callout for mapping
       const auto& mapping = tgt->getRocErxMapping();
       try {
-
         auto [first_erx, first_ch] = mapping.toErxChannel(i_roc, 0);
         auto [last_erx, last_ch] = mapping.toErxChannel(i_roc, 71);
 
         if (toa_vref == 0) {
-          pflib_log(info) << "[DEBUG MAP] Mapping Check for ROC " << i_roc << ":"
-                          << " Ch 0  -> eRx " << (int)first_erx << ", eCh " << (int)first_ch
-                          << " | Ch 71  -> eRx " << (int)last_erx << ", eCh " << (int)last_ch;
+          pflib_log(info) << "[DEBUG MAP] Mapping Check for ROC " << i_roc
+                          << ":"
+                          << " Ch 0  -> eRx " << (int)first_erx << ", eCh "
+                          << (int)first_ch << " | Ch 71  -> eRx "
+                          << (int)last_erx << ", eCh " << (int)last_ch;
         }
       }
 
       catch (const std::exception& e) {
-        pflib_log(error) << "[DEBUG MAP] Critical: Mapping lookup threw an exception for ROC "
+        pflib_log(error) << "[DEBUG MAP] Critical: Mapping lookup threw an "
+                            "exception for ROC "
                          << i_roc << ". Message: " << e.what();
-
       }
 
-      auto efficiencies = get_toa_efficiencies(i_roc, mapping, buffer.get_buffer());
+      auto efficiencies =
+          get_toa_efficiencies(i_roc, mapping, buffer.get_buffer());
 
       pflib_log(trace) << "got channel efficiencies for ROC " << i_roc
                        << ", getting max efficiency per link";
 
-      for (int i_link{0}; i_link < 2; i_link++){
+      for (int i_link{0}; i_link < 2; i_link++) {
         auto start = efficiencies.begin() + 36 * i_link;
         auto end = start + 36;
         double max_eff = *std::max_element(start, end);
@@ -83,13 +79,13 @@ std::map<int, std::map<std::string, std::map<std::string, uint64_t>>> toa_vref_s
         final_effs[i_roc][i_link][toa_vref] = max_eff;
 
         if (toa_vref % 32 == 0 || max_eff > 0.0) {
-          pflib_log(trace) << "[DEBUG SCAN] VREF " << toa_vref
-                           << " | ROC " << i_roc << " Link " << i_link
+          pflib_log(trace) << "[DEBUG SCAN] VREF " << toa_vref << " | ROC "
+                           << i_roc << " Link " << i_link
                            << " | Max Efficiency: " << max_eff;
         }
       }
 
-      pflib_log(trace) << "got link efficiencies"; 
+      pflib_log(trace) << "got link efficiencies";
     }
   }
 
@@ -99,38 +95,41 @@ std::map<int, std::map<std::string, std::map<std::string, uint64_t>>> toa_vref_s
 
   for (int i_roc : tgt->roc_ids()) {
     for (int i_link{0}; i_link < 2; i_link++) {
+      int highest_non_zero_eff =
+          -1;  // just a placeholder in case it's not found
 
-      int highest_non_zero_eff = -1;  // just a placeholder in case it's not found
-
-      for (int toa_vref = final_effs[i_roc][i_link].size() - 1; toa_vref >= 0; toa_vref--) {
+      for (int toa_vref = final_effs[i_roc][i_link].size() - 1; toa_vref >= 0;
+           toa_vref--) {
         if (toa_vref == (int)final_effs[i_roc][i_link].size() - 1) {
-          pflib_log(trace) << "[DEBUG SEARCH] Starting backwards search for ROC " << i_roc
-                           << " Link " << i_link << ". Initial val at max VREF: "
-                           << final_effs[i_roc][i_link][toa_vref];
+          pflib_log(trace)
+              << "[DEBUG SEARCH] Starting backwards search for ROC " << i_roc
+              << " Link " << i_link << ". Initial val at max VREF: "
+              << final_effs[i_roc][i_link][toa_vref];
         }
 
         if (final_effs[i_roc][i_link][toa_vref] > 0.0) {
           highest_non_zero_eff =
               toa_vref + 10;  // need to add 10 since we don't want to overlap
                               // with highest pedestals!
-          pflib_log(info) << "[DEBUG SEARCH] Success. Found threshold edge at VREF " << toa_vref
-                          << " (Setting target to " << highest_non_zero_eff << ")";
-          break;              // should break from link 0 into link 1
+          pflib_log(info)
+              << "[DEBUG SEARCH] Success. Found threshold edge at VREF "
+              << toa_vref << " (Setting target to " << highest_non_zero_eff
+              << ")";
+          break;  // should break from link 0 into link 1
         }
       }
 
       if (highest_non_zero_eff < 0) {
         pflib_log(warn) << "ROC " << i_roc << " link " << i_link
-                           << ": no non-zero TOA efficiency found, skipping";
+                        << ": no non-zero TOA efficiency found, skipping";
         continue;
       }
 
       if (highest_non_zero_eff > 255) {
         pflib_log(warn) << "ROC " << i_roc << " link " << i_link
-                           << ": deduced TOA_VREF " << highest_non_zero_eff
-                           << " out of range, clamping to 255";
+                        << ": deduced TOA_VREF " << highest_non_zero_eff
+                        << " out of range, clamping to 255";
         highest_non_zero_eff = 255;
-
       }
       target[i_roc][i_link] = highest_non_zero_eff;  // store value
     }

--- a/app/tool/algorithm/toa_vref_scan.cxx
+++ b/app/tool/algorithm/toa_vref_scan.cxx
@@ -1,16 +1,16 @@
 #include "toa_vref_scan.h"
-
 #include "../daq_run.h"
 #include "../tasks/toa_vref_scan.h"
 #include "get_toa_efficiencies.h"
 #include "pflib/utility/efficiency.h"
 #include "pflib/utility/string_format.h"
-
 namespace pflib::algorithm {
 
-std::map<std::string, std::map<std::string, uint64_t>> toa_vref_scan(
-    Target* tgt, ROC roc) {
+std::map<int, std::map<std::string, std::map<std::string, uint64_t>>> toa_vref_scan(
+    Target* tgt) {
   static auto the_log_{::pflib::logging::get("toa_vref_scan")};
+
+
 
   /// do a run of 100 samples per toa_vref to measure the TOA
   /// efficiency when looking at pedestal data
@@ -19,58 +19,130 @@ std::map<std::string, std::map<std::string, uint64_t>> toa_vref_scan(
 
   tgt->setup_run(1, Target::DaqFormat::ECOND_SW_HEADERS, 1);
 
-  std::array<int, 2> target;
-  std::array<std::array<double, 256>, 2> final_effs;
+  std::map<int, std::array<int, 2>> target;  // i_roc int for each variable
+  std::map<int, std::array<std::array<double, 256>, 2>> final_effs;
+  std::map<int, std::map<std::string, std::map<std::string, uint64_t>>> settings;
+
+
+
   // TODO 348
-  DecodeAndBuffer buffer{n_events, 2};
+
+  DecodeAndBuffer buffer{n_events, tgt->nrocs() * 2};
+
+
 
   // loop over runs, from toa_vref = 0 to = 255
+
   for (int toa_vref{0}; toa_vref < 256; toa_vref++) {
     pflib_log(info) << "testing toa_vref = " << toa_vref;
-    auto test_handle = roc.testParameters()
-                           .add("REFERENCEVOLTAGE_0", "TOA_VREF", toa_vref)
-                           .add("REFERENCEVOLTAGE_1", "TOA_VREF", toa_vref)
-                           .apply();
+
+    std::map<std::string, std::map<std::string, uint64_t>> parameters;
+    parameters["REFERENCEVOLTAGE_0"]["TOA_VREF"] = toa_vref;
+    parameters["REFERENCEVOLTAGE_1"]["TOA_VREF"] = toa_vref;
+    auto test_params = tgt->tempApplyAllROCs(parameters);
+
     usleep(10);
+
     daq_run(tgt, "PEDESTAL", buffer, n_events, 100);
     pflib_log(trace) << "finished toa_vref = " << toa_vref
                      << ", getting efficiencies";
-    auto efficiencies = get_toa_efficiencies(buffer.get_buffer());
-    pflib_log(trace)
-        << "got channel efficiencies, getting max efficiency per link";
-    for (int i_link{0}; i_link < 2; i_link++) {
-      auto start = efficiencies.begin() +
-                   36 * i_link;  // start at 0 for link 0, 36 for link 1
-      auto end = start + 36;
-      final_effs[i_link][toa_vref] = *std::max_element(start, end);
+
+
+
+    for (int i_roc : tgt->roc_ids()) {
+      // Debug callout for mapping
+      const auto& mapping = tgt->getRocErxMapping();
+      try {
+
+        auto [first_erx, first_ch] = mapping.toErxChannel(i_roc, 0);
+        auto [last_erx, last_ch] = mapping.toErxChannel(i_roc, 71);
+
+        if (toa_vref == 0) {
+          pflib_log(info) << "[DEBUG MAP] Mapping Check for ROC " << i_roc << ":"
+                          << " Ch 0  -> eRx " << (int)first_erx << ", eCh " << (int)first_ch
+                          << " | Ch 71  -> eRx " << (int)last_erx << ", eCh " << (int)last_ch;
+        }
+      }
+
+      catch (const std::exception& e) {
+        pflib_log(error) << "[DEBUG MAP] Critical: Mapping lookup threw an exception for ROC "
+                         << i_roc << ". Message: " << e.what();
+
+      }
+
+      auto efficiencies = get_toa_efficiencies(i_roc, mapping, buffer.get_buffer());
+
+      pflib_log(trace) << "got channel efficiencies for ROC " << i_roc
+                       << ", getting max efficiency per link";
+
+      for (int i_link{0}; i_link < 2; i_link++){
+        auto start = efficiencies.begin() + 36 * i_link;
+        auto end = start + 36;
+        double max_eff = *std::max_element(start, end);
+
+        final_effs[i_roc][i_link][toa_vref] = max_eff;
+
+        if (toa_vref % 32 == 0 || max_eff > 0.0) {
+          pflib_log(trace) << "[DEBUG SCAN] VREF " << toa_vref
+                           << " | ROC " << i_roc << " Link " << i_link
+                           << " | Max Efficiency: " << max_eff;
+        }
+      }
+
+      pflib_log(trace) << "got link efficiencies"; 
     }
-    pflib_log(trace) << "got link efficiencies";
   }
 
   pflib_log(info) << "sample collections done, deducing settings";
   // get the max toa_vref with non-zero efficiency? Iterate through the array
   // from bottom up.
-  for (int i_link{0}; i_link < 2; i_link++) {
-    int highest_non_zero_eff = -1;  // just a placeholder in case it's not found
-    for (int toa_vref = final_effs[0].size() - 1; toa_vref >= 0; toa_vref--) {
-      if (final_effs[i_link][toa_vref] > 0.0) {
-        highest_non_zero_eff =
-            toa_vref + 10;  // need to add 10 since we don't want to overlap
-                            // with highest pedestals!
-        break;              // should break from link 0 into link 1
+
+  for (int i_roc : tgt->roc_ids()) {
+    for (int i_link{0}; i_link < 2; i_link++) {
+
+      int highest_non_zero_eff = -1;  // just a placeholder in case it's not found
+
+      for (int toa_vref = final_effs[i_roc][i_link].size() - 1; toa_vref >= 0; toa_vref--) {
+        if (toa_vref == (int)final_effs[i_roc][i_link].size() - 1) {
+          pflib_log(trace) << "[DEBUG SEARCH] Starting backwards search for ROC " << i_roc
+                           << " Link " << i_link << ". Initial val at max VREF: "
+                           << final_effs[i_roc][i_link][toa_vref];
+        }
+
+        if (final_effs[i_roc][i_link][toa_vref] > 0.0) {
+          highest_non_zero_eff =
+              toa_vref + 10;  // need to add 10 since we don't want to overlap
+                              // with highest pedestals!
+          pflib_log(info) << "[DEBUG SEARCH] Success. Found threshold edge at VREF " << toa_vref
+                          << " (Setting target to " << highest_non_zero_eff << ")";
+          break;              // should break from link 0 into link 1
+        }
       }
+
+      if (highest_non_zero_eff < 0) {
+        pflib_log(warn) << "ROC " << i_roc << " link " << i_link
+                           << ": no non-zero TOA efficiency found, skipping";
+        continue;
+      }
+
+      if (highest_non_zero_eff > 255) {
+        pflib_log(warn) << "ROC " << i_roc << " link " << i_link
+                           << ": deduced TOA_VREF " << highest_non_zero_eff
+                           << " out of range, clamping to 255";
+        highest_non_zero_eff = 255;
+
+      }
+      target[i_roc][i_link] = highest_non_zero_eff;  // store value
     }
-    target[i_link] = highest_non_zero_eff;  // store value
-  }
-  // toa_vref is a global parameter (1 value per link)
 
-  std::map<std::string, std::map<std::string, uint64_t>> settings;
-  for (int i_link{0}; i_link < 2; i_link++) {
-    std::string page{
-        pflib::utility::string_format("REFERENCEVOLTAGE_%d", i_link)};
-    settings[page]["TOA_VREF"] = target[i_link];
-  }
+    // toa_vref is a global parameter (1 value per link)
 
+    for (int i_link{0}; i_link < 2; i_link++) {
+      std::string page{
+          pflib::utility::string_format("REFERENCEVOLTAGE_%d", i_link)};
+      settings[i_roc][page]["TOA_VREF"] = target[i_roc][i_link];
+    }
+  }
   return settings;
 }
 

--- a/app/tool/algorithm/toa_vref_scan.h
+++ b/app/tool/algorithm/toa_vref_scan.h
@@ -15,7 +15,7 @@ namespace pflib::algorithm {
  *
  * @note Only functional for single-ROC targets
  */
-std::map<std::string, std::map<std::string, uint64_t>> toa_vref_scan(
-    Target* tgt, ROC roc);
+std::map<int , std::map<std::string, std::map<std::string, uint64_t>>> toa_vref_scan(
+    Target* tgt);
 
 }  // namespace pflib::algorithm

--- a/app/tool/algorithm/toa_vref_scan.h
+++ b/app/tool/algorithm/toa_vref_scan.h
@@ -15,7 +15,7 @@ namespace pflib::algorithm {
  *
  * @note Only functional for single-ROC targets
  */
-std::map<int , std::map<std::string, std::map<std::string, uint64_t>>> toa_vref_scan(
-    Target* tgt);
+std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>
+toa_vref_scan(Target* tgt);
 
 }  // namespace pflib::algorithm

--- a/app/tool/algorithm/trim_toa_scan.cxx
+++ b/app/tool/algorithm/trim_toa_scan.cxx
@@ -1,12 +1,14 @@
 #include "trim_toa_scan.h"
+
+#include <fstream>
+#include <numeric>
+#include <vector>
+
 #include "../daq_run.h"
 #include "../tasks/trim_toa_scan.h"
 #include "get_toa_efficiencies.h"
 #include "pflib/utility/median.h"
 #include "pflib/utility/string_format.h"
-#include <numeric>
-#include <vector>
-#include <fstream>
 
 /**
  * Perform a linear regression using the
@@ -26,7 +28,11 @@
 std::tuple<double, double> siegel_regression(
     const std::vector<double>& x_vals, const std::vector<double>& y_vals) {
   if (x_vals.size() != y_vals.size()) {
-    throw std::invalid_argument("x_vals and y_vals must be the same size."); //applies a check to see if the data that it is analyzing is of a suitable size
+    throw std::invalid_argument(
+        "x_vals and y_vals must be the same size.");  // applies a check to see
+                                                      // if the data that it is
+                                                      // analyzing is of a
+                                                      // suitable size
   }
   std::cout << "x_vals: ";
   for (const auto& val : x_vals) std::cout << val << " ";
@@ -37,7 +43,8 @@ std::tuple<double, double> siegel_regression(
   std::cout << std::endl;
 
   size_t n = x_vals.size();
-  // std::cout << "x_vals have length:" << x_vals.size(); used to check size of data, is redundant
+  // std::cout << "x_vals have length:" << x_vals.size(); used to check size of
+  // data, is redundant
   std::vector<double> slopes;
   slopes.reserve(n * n);
   for (size_t i = 0; i < n; ++i) {
@@ -45,18 +52,21 @@ std::tuple<double, double> siegel_regression(
       if (x_vals[j] != x_vals[i]) {
         slopes.push_back((y_vals[j] - y_vals[i]) / (x_vals[j] - x_vals[i]));
       }
-      //else {
-        //slopes.push_back((y_vals[j] - y_vals[i])); //Changed to make it so that if there is an issue with the two x vals being too close together
-      //}                                       //we will just estimate that the difference in calib is ~1 (should hopefully still produce a slope)
+      // else {
+      // slopes.push_back((y_vals[j] - y_vals[i])); //Changed to make it so that
+      // if there is an issue with the two x vals being too close together
+      //}                                       //we will just estimate that the
+      //difference in calib is ~1 (should hopefully still produce a slope)
     }
   }
-  std::cout << "total slope size" << slopes.size(); //debug statement
+  std::cout << "total slope size" << slopes.size();  // debug statement
   if (slopes.empty()) {
-     throw std::invalid_argument("slopes was found to be empty, may lack more than 1 unique x value");
-}
+    throw std::invalid_argument(
+        "slopes was found to be empty, may lack more than 1 unique x value");
+  }
 
   double slope = pflib::utility::median(slopes);
-  //std::cout << "median slope was found" << std::endl;
+  // std::cout << "median slope was found" << std::endl;
 
   std::vector<double> intercepts;
   intercepts.reserve(n);
@@ -66,9 +76,9 @@ std::tuple<double, double> siegel_regression(
   }
 
   double intercept = pflib::utility::median(intercepts);
-  //std::cout << "median intercept was found" << std::endl;
+  // std::cout << "median intercept was found" << std::endl;
   return std::make_tuple(slope, intercept);
-  }
+}
 
 /**
  * Calculate the TRIM_TOA for each channel that best aligns all of them
@@ -76,9 +86,10 @@ std::tuple<double, double> siegel_regression(
  */
 
 namespace pflib::algorithm {
-std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>trim_toa_scan(  //This is needed to run for multiple attached ROCs
-    Target* tgt)
-{static auto the_log_{::pflib::logging::get("trim_toa_scan")};
+std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>
+trim_toa_scan(  // This is needed to run for multiple attached ROCs
+    Target* tgt) {
+  static auto the_log_{::pflib::logging::get("trim_toa_scan")};
 
   /**
    * Charge injection scan (100 samples) while varying TRIM_TOA.
@@ -91,18 +102,28 @@ std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>trim_toa_sc
    */
   static const std::size_t n_events = 10;
   tgt->setup_run(1, Target::DaqFormat::ECOND_SW_HEADERS, 1);
-  tgt->fc().fc_setup_calib(17); //Sets the bunch crossing value, this one may be optimal for only one of the links
+  tgt->fc().fc_setup_calib(17);  // Sets the bunch crossing value, this one may
+                                 // be optimal for only one of the links
   // trim_toa is a channel-wise parameter (1 value per channel)
   int calib_step = 10;
   int trim_toa_step = 2;
   int trim_toa_max = 20;
   int calib_max = 200;
-  //std::array<std::array<std::array<double, 72>, 8>, 200> final_data; ORIGINAL ARRAY.
-  //Has been changed based on the size of the scan I am running, edit in the above variables
-  auto final_data = std::vector<std::vector<std::vector<std::vector<double>>>>(tgt -> nrocs(), std::vector<std::vector<std::vector<double>>>((calib_max/calib_step) , std::vector<std::vector<double>>((trim_toa_max/trim_toa_step), std::vector<double>(72, 0))));  //was originally 200 x 8 x 72
-  // working in buffer, not in writer, changed to not start trim_toa at 0 but instead at 12
-  DecodeAndBuffer buffer{n_events, tgt -> nrocs() * 2};
-  std::map<int, int> roc_index; //Added to stop final_data from being out of bounds
+  // std::array<std::array<std::array<double, 72>, 8>, 200> final_data; ORIGINAL
+  // ARRAY. Has been changed based on the size of the scan I am running, edit in
+  // the above variables
+  auto final_data = std::vector<std::vector<std::vector<std::vector<double>>>>(
+      tgt->nrocs(),
+      std::vector<std::vector<std::vector<double>>>(
+          (calib_max / calib_step),
+          std::vector<std::vector<double>>(
+              (trim_toa_max / trim_toa_step),
+              std::vector<double>(72, 0))));  // was originally 200 x 8 x 72
+  // working in buffer, not in writer, changed to not start trim_toa at 0 but
+  // instead at 12
+  DecodeAndBuffer buffer{n_events, tgt->nrocs() * 2};
+  std::map<int, int>
+      roc_index;  // Added to stop final_data from being out of bounds
 
   int count = 0;
   for (int i_roc : tgt->roc_ids()) {
@@ -110,31 +131,35 @@ std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>trim_toa_sc
     count += 1;
   }
 
-  // loop over trim_toa, over the full range of 0 to 31  with a stepsize of trim_toa_step
-  // loop over the ROCs and each of the channels
-  // loop over calib, stepsize of calib_step over a range of CALIB = 0 to 800
- const pflib::packing::SingleECONDRocErxMapping& mapping = tgt->getRocErxMapping();
+  // loop over trim_toa, over the full range of 0 to 31  with a stepsize of
+  // trim_toa_step loop over the ROCs and each of the channels loop over calib,
+  // stepsize of calib_step over a range of CALIB = 0 to 800
+  const pflib::packing::SingleECONDRocErxMapping& mapping =
+      tgt->getRocErxMapping();
 
-
-std::map<std::string, std::map<std::string, uint64_t>> charge_active;
-for (int i_link{0}; i_link < 2; i_link++) {
-      std::string refvol_page{pflib::utility::string_format("REFERENCEVOLTAGE_%d", i_link)};
-      charge_active[refvol_page]["INTCTEST"] = 1;
-      charge_active[refvol_page]["CHOICE_CINJ"] = 1;
-      }
-auto charge_params = tgt->tempApplyAllROCs(charge_active);
-//pflib_log(info) << "Applied charge params";
+  std::map<std::string, std::map<std::string, uint64_t>> charge_active;
+  for (int i_link{0}; i_link < 2; i_link++) {
+    std::string refvol_page{
+        pflib::utility::string_format("REFERENCEVOLTAGE_%d", i_link)};
+    charge_active[refvol_page]["INTCTEST"] = 1;
+    charge_active[refvol_page]["CHOICE_CINJ"] = 1;
+  }
+  auto charge_params = tgt->tempApplyAllROCs(charge_active);
+  // pflib_log(info) << "Applied charge params";
 
   for (int trim_toa{0}; trim_toa < trim_toa_max; trim_toa += trim_toa_step) {
     pflib_log(info) << "testing trim_toa = " << trim_toa;
-    for (int calib = 0; calib < calib_max; calib += calib_step ) {
+    for (int calib = 0; calib < calib_max; calib += calib_step) {
       std::map<std::string, std::map<std::string, uint64_t>> parameters;
-      //std::string refvol_page{pflib::utility::string_format("REFERENCEVOLTAGE_%d", i_link)};
+      // std::string
+      // refvol_page{pflib::utility::string_format("REFERENCEVOLTAGE_%d",
+      // i_link)};
 
       for (int i_link{0}; i_link < 2; i_link++) {
-      pflib_log(info) << "Before Applied CALIB";
-      std::string refvol_page{pflib::utility::string_format("REFERENCEVOLTAGE_%d", i_link)};
-      parameters[refvol_page]["CALIB"] = calib;
+        pflib_log(info) << "Before Applied CALIB";
+        std::string refvol_page{
+            pflib::utility::string_format("REFERENCEVOLTAGE_%d", i_link)};
+        parameters[refvol_page]["CALIB"] = calib;
       }
       auto test_params = tgt->tempApplyAllROCs(parameters);
       pflib_log(info) << "Applied CALIB = " << calib << " on both links";
@@ -154,56 +179,64 @@ auto charge_params = tgt->tempApplyAllROCs(charge_active);
         parameters2[ch_str]["HIGHRANGE"] = 0;
         auto test_params2 = tgt->tempApplyAllROCs(parameters2);
 
-        //pflib_log(trace) << "finished trim_toa = " << trim_toa << ", and calib = " << calib << ", getting efficiencies";
+        // pflib_log(trace) << "finished trim_toa = " << trim_toa << ", and
+        // calib = " << calib << ", getting efficiencies";
         auto data = buffer.get_buffer();
         int length = data.size();
-        //pflib_log(info) << "length = " << length << "\n";
-        for (int i_roc : tgt->roc_ids()){
+        // pflib_log(info) << "length = " << length << "\n";
+        for (int i_roc : tgt->roc_ids()) {
           int toa_count = 0;
           auto [i_erx, i_ch] = mapping.toErxChannel(i_roc, ch);
 
-          for (std::size_t i = 0; i < length; i++){
+          for (std::size_t i = 0; i < length; i++) {
             double toa = data[i].soi().channel(i_erx, i_ch).toa();
-            if (toa > 0){
+            if (toa > 0) {
               ++toa_count;
-              }
+            }
           }
 
-      double percent = ((toa_count * 1.0) / length);
-      //pflib_log(info) << " percent = " << percent << "\n";
-      //auto efficiencies = get_toa_efficiencies(i_roc, mapping, buffer.get_buffer()) ;
-      //pflib_log(info) << "got channel efficiencies, storing now" ;
-      // need to divide by 4 because index is value/4 from final_data, initialization and for loop
-      final_data[roc_index[i_roc]][calib / calib_step][trim_toa / trim_toa_step][ch] = percent; //sets data to be called later as threshold value
+          double percent = ((toa_count * 1.0) / length);
+          // pflib_log(info) << " percent = " << percent << "\n";
+          // auto efficiencies = get_toa_efficiencies(i_roc, mapping,
+          // buffer.get_buffer()) ; pflib_log(info) << "got channel
+          // efficiencies, storing now" ;
+          //  need to divide by 4 because index is value/4 from final_data,
+          //  initialization and for loop
+          final_data[roc_index[i_roc]][calib / calib_step][trim_toa /
+                                                           trim_toa_step][ch] =
+              percent;  // sets data to be called later as threshold value
 
-      if (percent > 0.9) {
-      std::cout << "non-negligable efficiency: ch=" << ch << " calib=" << calib << " ROC=" << i_roc << " trim_toa=" << trim_toa << " eff=" << percent << std::endl; //print with useful data
-      }
-
-     }
-    }
-   }
-  }
-
-pflib_log(info) << "sample collections done, deducing settings";
-
-//saving the efficiencies to a csv file to have to run this files less times
-std::ofstream csv_file("toa_efficiencies.csv");
-for (int i_roc : tgt->roc_ids()) {
-  for (int trim_toa{0}; trim_toa < trim_toa_max ; trim_toa += trim_toa_step) {
-    for (int ch{0}; ch < 72; ch++) {
-      for (int calib{0}; calib < calib_max ; calib += calib_step) {
-        // divide by the proper stepsize for indexing
-        double efficiency = final_data[roc_index[i_roc]][calib / calib_step][trim_toa / trim_toa_step][ch];
-        csv_file << i_roc << "," << ch << "," << trim_toa << "," << calib << "," << efficiency << "\n";
+          if (percent > 0.9) {
+            std::cout << "non-negligable efficiency: ch=" << ch
+                      << " calib=" << calib << " ROC=" << i_roc
+                      << " trim_toa=" << trim_toa << " eff=" << percent
+                      << std::endl;  // print with useful data
+          }
+        }
       }
     }
   }
-}
 
+  pflib_log(info) << "sample collections done, deducing settings";
 
+  // saving the efficiencies to a csv file to have to run this files less times
+  std::ofstream csv_file("toa_efficiencies.csv");
+  for (int i_roc : tgt->roc_ids()) {
+    for (int trim_toa{0}; trim_toa < trim_toa_max; trim_toa += trim_toa_step) {
+      for (int ch{0}; ch < 72; ch++) {
+        for (int calib{0}; calib < calib_max; calib += calib_step) {
+          // divide by the proper stepsize for indexing
+          double efficiency = final_data[roc_index[i_roc]][calib / calib_step]
+                                        [trim_toa / trim_toa_step][ch];
+          csv_file << i_roc << "," << ch << "," << trim_toa << "," << calib
+                   << "," << efficiency << "\n";
+        }
+      }
+    }
+  }
 
-//Saving the efficiencies data so this does not need to be redone over and over again
+  // Saving the efficiencies data so this does not need to be redone over and
+  // over again
 
   /**
    * Now that we have the data, we need to analyze it.
@@ -221,86 +254,106 @@ for (int i_roc : tgt->roc_ids()) {
   // "threshold_points" is a 2D vector.
   // Column 1 is channel index, Column 2 is calib, Column 3 is trim_toa.
   std::vector<std::vector<int>> threshold_points;
-  //std::vector<int> calib_vals;
-  // Each channel has multiple threshold points, but we don't know how many yet
+  // std::vector<int> calib_vals;
+  //  Each channel has multiple threshold points, but we don't know how many yet
 
-pflib_log(trace) << "assigning threshold values";
-for (int i_roc : tgt->roc_ids()) {
-  for (int trim_toa{0}; trim_toa < trim_toa_max; trim_toa += trim_toa_step) {
-    for (int ch{0}; ch < 72; ch++) {
-      for (int calib{0}; calib < calib_max ; calib += calib_step) {
-        // divide by the proper stepsize to convert value to index
-        if (final_data[roc_index[i_roc]][calib / calib_step][trim_toa / trim_toa_step][ch]> 0.6) {
-          threshold_points.push_back({ch, calib, trim_toa, i_roc});
-          //calib_vals.push_back(calib);
-          break;
+  pflib_log(trace) << "assigning threshold values";
+  for (int i_roc : tgt->roc_ids()) {
+    for (int trim_toa{0}; trim_toa < trim_toa_max; trim_toa += trim_toa_step) {
+      for (int ch{0}; ch < 72; ch++) {
+        for (int calib{0}; calib < calib_max; calib += calib_step) {
+          // divide by the proper stepsize to convert value to index
+          if (final_data[roc_index[i_roc]][calib / calib_step]
+                        [trim_toa / trim_toa_step][ch] > 0.6) {
+            threshold_points.push_back({ch, calib, trim_toa, i_roc});
+            // calib_vals.push_back(calib);
+            break;
+          }
         }
       }
     }
   }
-}
 
-pflib_log(trace) << "Completed Assigning Threshold Values";
-//int calib_med = pflib::utility::median(calib_vals) ;
-int calib_tgt = 40 ;  //base this value around what your target calib value is for the highrange
+  pflib_log(trace) << "Completed Assigning Threshold Values";
+  // int calib_med = pflib::utility::median(calib_vals) ;
+  int calib_tgt = 40;  // base this value around what your target calib value is
+                       // for the highrange
 
+  // get vector of data points for each channel.
+  std::map<int, std::array<int, 72>> target;
+  for (int i_roc : tgt->roc_ids()) {
+    std::vector<uint64_t>
+        avg_toa_vals;  // For the averaging for the channels that are missing
+                       // data, it is designed to have them be calculated per
+                       // ROC, as I have found that the behaviors of the data
+                       // for each ROC seems to be unique to each chip
+    for (int ch{0}; ch < 72; ch++) {
+      std::vector<double> calib;
+      std::vector<double> trim_toa;
 
-// get vector of data points for each channel.
-std::map<int, std::array<int, 72>> target;
-for (int i_roc : tgt-> roc_ids()) {
-  std::vector<uint64_t> avg_toa_vals; //For the averaging for the channels that are missing data, it is designed to have them be calculated per
-                                      //ROC, as I have found that the behaviors of the data for each ROC seems to be unique to each chip
-  for (int ch{0}; ch < 72; ch++) {
-    std::vector<double> calib;
-    std::vector<double> trim_toa;
+      for (const auto& row : threshold_points) {
+        if (row[3] == i_roc) {
+          if (row[0] == ch) {
+            calib.push_back(row[1]);
+            trim_toa.push_back(row[2]);
+          }
+        }
+      }
+      if (calib.size() <
+          2) {  // Code made to remove the data that was too insignificant
+        std::cout << "Skipping channel " << ch
+                  << " due to insufficient points, setting to be middle value ("
+                  << calib.size() << ")" << std::endl;
+        // Need to have this averaging because some of the channels simply dont
+        // capture any data at all (some of them are dead, but those dont factor
+        // into calculating this average)
+        target[roc_index[i_roc]][ch] = static_cast<int>(
+            -1);  // Identify these dead channels as 0, which is a value none of
+                  // the working channels produce
+        continue;
+      }
+      // std::cout << "x_vals size: " << calib.size() << ", y_vals size: " <<
+      // trim_toa.size() << std::endl;
+      auto [slope, intercept] = siegel_regression(
+          calib, trim_toa);  // applies the Siegel regression to your data
+      pflib_log(trace) << "Slope value was found to be = " << slope << "\n";
+      int optimal_trim_val_round =
+          static_cast<int>(std::round(calib_tgt * slope + intercept));
+      pflib_log(trace) << "Appended optimal_trim_val ="
+                       << optimal_trim_val_round;
+      int optimal_trim_val_clam = std::clamp(optimal_trim_val_round, 0, 63);
+      int optimal_trim_val = static_cast<uint64_t>(
+          std::round(optimal_trim_val_clam));  // apply settings to make the
+                                               // optimal trim more reasonable
+      target[roc_index[i_roc]][ch] = static_cast<uint64_t>(optimal_trim_val);
+      avg_toa_vals.push_back(optimal_trim_val);  // append data to be averaged
+    }
 
-    for (const auto& row : threshold_points) {
-      if (row[3] == i_roc){
-      if (row[0] == ch) {
-        calib.push_back(row[1]);
-        trim_toa.push_back(row[2]);
-       }
+    int sum = std::reduce(avg_toa_vals.begin(), avg_toa_vals.end(), 0);
+    int average =
+        std::round(std::reduce(avg_toa_vals.begin(), avg_toa_vals.end(), 0.0) /
+                   avg_toa_vals.size());
+
+    for (int ch = 0; ch < 72; ch++) {
+      if (target[roc_index[i_roc]][ch] == -1) {
+        target[roc_index[i_roc]][ch] = average;
       }
     }
-    if (calib.size() < 2) { //Code made to remove the data that was too insignificant
-    std::cout << "Skipping channel " << ch << " due to insufficient points, setting to be middle value (" << calib.size() << ")" << std::endl;
-    //Need to have this averaging because some of the channels simply dont capture any data at all (some of them are dead, but those dont factor into calculating this average)
-    target[roc_index[i_roc]][ch] = static_cast<int>(-1); //Identify these dead channels as 0, which is a value none of the working channels produce
-    continue;
+
+    pflib_log(trace) << "did the averaging and found it to be:" << average;
+    pflib_log(info) << "Completed Regression";
+  }
+
+  pflib_log(trace) << "writing TRIM_TOA settings";
+
+  std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>
+      settings;
+  for (int i_roc : tgt->roc_ids()) {
+    for (int ch{0}; ch < 72; ch++) {
+      std::string page{pflib::utility::string_format("CH_%d", ch)};
+      settings[i_roc][page]["TRIM_TOA"] = target[roc_index[i_roc]][ch];
     }
-    //std::cout << "x_vals size: " << calib.size() << ", y_vals size: " << trim_toa.size() << std::endl;
-    auto [slope, intercept] = siegel_regression(calib, trim_toa);  //applies the Siegel regression to your data
-    pflib_log(trace) << "Slope value was found to be = " << slope << "\n";
-    int optimal_trim_val_round =  static_cast<int>(std::round(calib_tgt * slope + intercept));
-    pflib_log(trace) << "Appended optimal_trim_val =" << optimal_trim_val_round;
-    int optimal_trim_val_clam = std::clamp(optimal_trim_val_round, 0, 63);
-    int optimal_trim_val =  static_cast<uint64_t>(std::round(optimal_trim_val_clam)); //apply settings to make the optimal trim more reasonable
-    target[roc_index[i_roc]][ch] = static_cast<uint64_t>(optimal_trim_val);
-    avg_toa_vals.push_back(optimal_trim_val); //append data to be averaged
- }
-
-int sum = std::reduce(avg_toa_vals.begin(), avg_toa_vals.end(), 0);
-int average = std::round(std::reduce(avg_toa_vals.begin(), avg_toa_vals.end(), 0.0) / avg_toa_vals.size());
-
-for (int ch = 0; ch < 72; ch++) {
-    if (target[roc_index[i_roc]][ch] == -1) {
-        target[roc_index[i_roc]][ch] = average;
-    }
-    }
-
-pflib_log(trace) << "did the averaging and found it to be:" << average;
-pflib_log(info) << "Completed Regression";
-}
-
-pflib_log(trace) << "writing TRIM_TOA settings";
-
-std::map<int, std::map<std::string, std::map<std::string, uint64_t>>> settings;
- for (int i_roc : tgt-> roc_ids()) {
-  for (int ch{0}; ch < 72; ch++) {
-    std::string page{pflib::utility::string_format("CH_%d", ch)};
-    settings[i_roc][page]["TRIM_TOA"] = target[roc_index[i_roc]][ch];
-}
-}
+  }
   return settings;
 }
 }  // namespace pflib::algorithm

--- a/app/tool/algorithm/trim_toa_scan.cxx
+++ b/app/tool/algorithm/trim_toa_scan.cxx
@@ -1,10 +1,12 @@
 #include "trim_toa_scan.h"
-
 #include "../daq_run.h"
 #include "../tasks/trim_toa_scan.h"
 #include "get_toa_efficiencies.h"
 #include "pflib/utility/median.h"
 #include "pflib/utility/string_format.h"
+#include <numeric>
+#include <vector>
+#include <fstream>
 
 /**
  * Perform a linear regression using the
@@ -20,53 +22,63 @@
  * @param[in] y_vals list of y-coordinate samples
  * @return 2-tuple of the form (slope, intercept)
  */
+
 std::tuple<double, double> siegel_regression(
     const std::vector<double>& x_vals, const std::vector<double>& y_vals) {
   if (x_vals.size() != y_vals.size()) {
-    throw std::invalid_argument("x_vals and y_vals must be the same size.");
+    throw std::invalid_argument("x_vals and y_vals must be the same size."); //applies a check to see if the data that it is analyzing is of a suitable size
   }
-  if (x_vals.empty()) {
-    throw std::invalid_argument("Input vectors must not be empty.");
-  }
+  std::cout << "x_vals: ";
+  for (const auto& val : x_vals) std::cout << val << " ";
+  std::cout << std::endl;
+
+  std::cout << "y_vals: ";
+  for (const auto& val : y_vals) std::cout << val << " ";
+  std::cout << std::endl;
 
   size_t n = x_vals.size();
-
+  // std::cout << "x_vals have length:" << x_vals.size(); used to check size of data, is redundant
   std::vector<double> slopes;
   slopes.reserve(n * n);
   for (size_t i = 0; i < n; ++i) {
     for (size_t j = i + 1; j < n; ++j) {
-      /**
-       * @note We are ignoring any pairs which would lead to division by zero.
-       */
       if (x_vals[j] != x_vals[i]) {
         slopes.push_back((y_vals[j] - y_vals[i]) / (x_vals[j] - x_vals[i]));
       }
+      //else {
+        //slopes.push_back((y_vals[j] - y_vals[i])); //Changed to make it so that if there is an issue with the two x vals being too close together
+      //}                                       //we will just estimate that the difference in calib is ~1 (should hopefully still produce a slope)
     }
   }
+  std::cout << "total slope size" << slopes.size(); //debug statement
+  if (slopes.empty()) {
+     throw std::invalid_argument("slopes was found to be empty, may lack more than 1 unique x value");
+}
 
   double slope = pflib::utility::median(slopes);
+  //std::cout << "median slope was found" << std::endl;
 
   std::vector<double> intercepts;
   intercepts.reserve(n);
+
   for (size_t i = 0; i < n; i++) {
     intercepts.push_back(y_vals[i] - slope * x_vals[i]);
   }
 
   double intercept = pflib::utility::median(intercepts);
+  //std::cout << "median intercept was found" << std::endl;
   return std::make_tuple(slope, intercept);
-}
+  }
 
 /**
  * Calculate the TRIM_TOA for each channel that best aligns all of them
  * to a common threshold voltage, charge injection pulse (calib).
- *
- * @note Not currently operational, but a good place to pickup from.
  */
-namespace pflib::algorithm {
 
-std::map<std::string, std::map<std::string, uint64_t>> trim_toa_scan(
-    Target* tgt, ROC roc) {
-  static auto the_log_{::pflib::logging::get("trim_toa_scan")};
+namespace pflib::algorithm {
+std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>trim_toa_scan(  //This is needed to run for multiple attached ROCs
+    Target* tgt)
+{static auto the_log_{::pflib::logging::get("trim_toa_scan")};
 
   /**
    * Charge injection scan (100 samples) while varying TRIM_TOA.
@@ -77,57 +89,121 @@ std::map<std::string, std::map<std::string, uint64_t>> trim_toa_scan(
    *
    * @note Reduce the sample size (ex: 100 to 10) to decrease the scan time.
    */
-
-  static const std::size_t n_events = 100;
-
+  static const std::size_t n_events = 10;
   tgt->setup_run(1, Target::DaqFormat::ECOND_SW_HEADERS, 1);
-
+  tgt->fc().fc_setup_calib(17); //Sets the bunch crossing value, this one may be optimal for only one of the links
   // trim_toa is a channel-wise parameter (1 value per channel)
-  std::array<uint64_t, 72> target;
+  int calib_step = 10;
+  int trim_toa_step = 2;
+  int trim_toa_max = 20;
+  int calib_max = 200;
+  //std::array<std::array<std::array<double, 72>, 8>, 200> final_data; ORIGINAL ARRAY.
+  //Has been changed based on the size of the scan I am running, edit in the above variables
+  auto final_data = std::vector<std::vector<std::vector<std::vector<double>>>>(tgt -> nrocs(), std::vector<std::vector<std::vector<double>>>((calib_max/calib_step) , std::vector<std::vector<double>>((trim_toa_max/trim_toa_step), std::vector<double>(72, 0))));  //was originally 200 x 8 x 72
+  // working in buffer, not in writer, changed to not start trim_toa at 0 but instead at 12
+  DecodeAndBuffer buffer{n_events, tgt -> nrocs() * 2};
+  std::map<int, int> roc_index; //Added to stop final_data from being out of bounds
 
-  // TODO 348
-  // 72 channels, 200 calib values, 8 trim_toa values. Only store toa_efficiency
-  // here.
-  std::array<std::array<std::array<double, 72>, 8>, 200> final_data;
-  // working in buffer, not in writer
-  DecodeAndBuffer buffer{n_events, 2};
+  int count = 0;
+  for (int i_roc : tgt->roc_ids()) {
+    roc_index[i_roc] = count;
+    count += 1;
+  }
 
-  // loop over trim_toa, from trim_toa = 0 to 32 by skipping 4
-  // loop over calib, from calib = 0 to 800 by skipping over 4
+  // loop over trim_toa, over the full range of 0 to 31  with a stepsize of trim_toa_step
+  // loop over the ROCs and each of the channels
+  // loop over calib, stepsize of calib_step over a range of CALIB = 0 to 800
+ const pflib::packing::SingleECONDRocErxMapping& mapping = tgt->getRocErxMapping();
 
-  for (int trim_toa{0}; trim_toa < 32; trim_toa += 4) {
+
+std::map<std::string, std::map<std::string, uint64_t>> charge_active;
+for (int i_link{0}; i_link < 2; i_link++) {
+      std::string refvol_page{pflib::utility::string_format("REFERENCEVOLTAGE_%d", i_link)};
+      charge_active[refvol_page]["INTCTEST"] = 1;
+      charge_active[refvol_page]["CHOICE_CINJ"] = 1;
+      }
+auto charge_params = tgt->tempApplyAllROCs(charge_active);
+//pflib_log(info) << "Applied charge params";
+
+  for (int trim_toa{0}; trim_toa < trim_toa_max; trim_toa += trim_toa_step) {
     pflib_log(info) << "testing trim_toa = " << trim_toa;
-    auto trim_toa_test_builder = roc.testParameters();
-    for (int ch{0}; ch < 72; ch++) {
-      trim_toa_test_builder.add("CH_" + std::to_string(ch), "TRIM_TOA",
-                                trim_toa);
-    }
-    // set TRIM_TOA for each channel
-    auto trim_toa_test = trim_toa_test_builder.apply();
-    usleep(10);
-    for (int calib = 0; calib < 800; calib += 4) {
-      pflib_log(info) << "Running CALIB = " << calib;
-      // set CALIB for each half
-      auto calib_test = roc.testParameters()
-                            .add("REFERENCEVOLTAGE_0", "CALIB", calib)
-                            .add("REFERENCEVOLTAGE_1", "CALIB", calib)
-                            .apply();
-      usleep(10);
-      daq_run(tgt, "CHARGE", buffer, n_events, 100);
+    for (int calib = 0; calib < calib_max; calib += calib_step ) {
+      std::map<std::string, std::map<std::string, uint64_t>> parameters;
+      //std::string refvol_page{pflib::utility::string_format("REFERENCEVOLTAGE_%d", i_link)};
 
-      pflib_log(trace) << "finished trim_toa = " << trim_toa
-                       << ", and calib = " << calib << ", getting efficiencies";
-      auto efficiencies = get_toa_efficiencies(buffer.get_buffer());
-      pflib_log(trace) << "got channel efficiencies, storing now";
+      for (int i_link{0}; i_link < 2; i_link++) {
+      pflib_log(info) << "Before Applied CALIB";
+      std::string refvol_page{pflib::utility::string_format("REFERENCEVOLTAGE_%d", i_link)};
+      parameters[refvol_page]["CALIB"] = calib;
+      }
+      auto test_params = tgt->tempApplyAllROCs(parameters);
+      pflib_log(info) << "Applied CALIB = " << calib << " on both links";
+
       for (int ch{0}; ch < 72; ch++) {
-        // need to divide by 4 because index is value/4 from final_data
-        // initialization and for loop
-        final_data[calib / 4][trim_toa / 4][ch] = efficiencies[ch];
+        // set TRIM_TOA for each channel
+        std::map<std::string, std::map<std::string, uint64_t>> param_ch;
+        std::string ch_str{"CH_" + std::to_string(ch)};
+        param_ch[ch_str]["TRIM_TOA"] = trim_toa;
+        param_ch[ch_str]["HIGHRANGE"] = 1;
+        param_ch[ch_str]["LOWRANGE"] = 0;
+        auto param_apply = tgt->tempApplyAllROCs(param_ch);
+        usleep(10);
+        daq_run(tgt, "CHARGE", buffer, n_events, pftool::state.daq_rate);
+
+        std::map<std::string, std::map<std::string, uint64_t>> parameters2;
+        parameters2[ch_str]["HIGHRANGE"] = 0;
+        auto test_params2 = tgt->tempApplyAllROCs(parameters2);
+
+        //pflib_log(trace) << "finished trim_toa = " << trim_toa << ", and calib = " << calib << ", getting efficiencies";
+        auto data = buffer.get_buffer();
+        int length = data.size();
+        //pflib_log(info) << "length = " << length << "\n";
+        for (int i_roc : tgt->roc_ids()){
+          int toa_count = 0;
+          auto [i_erx, i_ch] = mapping.toErxChannel(i_roc, ch);
+
+          for (std::size_t i = 0; i < length; i++){
+            double toa = data[i].soi().channel(i_erx, i_ch).toa();
+            if (toa > 0){
+              ++toa_count;
+              }
+          }
+
+      double percent = ((toa_count * 1.0) / length);
+      //pflib_log(info) << " percent = " << percent << "\n";
+      //auto efficiencies = get_toa_efficiencies(i_roc, mapping, buffer.get_buffer()) ;
+      //pflib_log(info) << "got channel efficiencies, storing now" ;
+      // need to divide by 4 because index is value/4 from final_data, initialization and for loop
+      final_data[roc_index[i_roc]][calib / calib_step][trim_toa / trim_toa_step][ch] = percent; //sets data to be called later as threshold value
+
+      if (percent > 0.9) {
+      std::cout << "non-negligable efficiency: ch=" << ch << " calib=" << calib << " ROC=" << i_roc << " trim_toa=" << trim_toa << " eff=" << percent << std::endl; //print with useful data
+      }
+
+     }
+    }
+   }
+  }
+
+pflib_log(info) << "sample collections done, deducing settings";
+
+//saving the efficiencies to a csv file to have to run this files less times
+std::ofstream csv_file("toa_efficiencies.csv");
+for (int i_roc : tgt->roc_ids()) {
+  for (int trim_toa{0}; trim_toa < trim_toa_max ; trim_toa += trim_toa_step) {
+    for (int ch{0}; ch < 72; ch++) {
+      for (int calib{0}; calib < calib_max ; calib += calib_step) {
+        // divide by the proper stepsize for indexing
+        double efficiency = final_data[roc_index[i_roc]][calib / calib_step][trim_toa / trim_toa_step][ch];
+        csv_file << i_roc << "," << ch << "," << trim_toa << "," << calib << "," << efficiency << "\n";
       }
     }
   }
+}
 
-  pflib_log(info) << "sample collections done, deducing settings";
+
+
+//Saving the efficiencies data so this does not need to be redone over and over again
 
   /**
    * Now that we have the data, we need to analyze it.
@@ -135,7 +211,6 @@ std::map<std::string, std::map<std::string, uint64_t>> trim_toa_scan(
    * We'll be looking for the turn-on (threshold) points for each channel
    * at each trim_toa value. The turn-on (threshold) point is the first
    * point where toa_efficiency goes from 0 to non-zero. The toa_efficiency
-   * is simply the number of times TOA triggers divided by the sample size, for
    * a given trim_toa/calib/channel combination.
    *
    * We'll be using the Siegel Linear Regression because it's less sensitive to
@@ -146,59 +221,86 @@ std::map<std::string, std::map<std::string, uint64_t>> trim_toa_scan(
   // "threshold_points" is a 2D vector.
   // Column 1 is channel index, Column 2 is calib, Column 3 is trim_toa.
   std::vector<std::vector<int>> threshold_points;
+  //std::vector<int> calib_vals;
+  // Each channel has multiple threshold points, but we don't know how many yet
 
-  // Each channel has multiple threshold points, but we don't know how many at
-  // the start.
-
-  for (int trim_toa{0}; trim_toa < 32; trim_toa += 4) {
+pflib_log(trace) << "assigning threshold values";
+for (int i_roc : tgt->roc_ids()) {
+  for (int trim_toa{0}; trim_toa < trim_toa_max; trim_toa += trim_toa_step) {
     for (int ch{0}; ch < 72; ch++) {
-      for (int calib{0}; calib < 800; calib += 4) {
-        // divide by 4 to convert value to index
-        if (final_data[calib / 4][trim_toa / 4][ch] > 0.0) {
-          threshold_points.push_back({ch, calib, trim_toa});
+      for (int calib{0}; calib < calib_max ; calib += calib_step) {
+        // divide by the proper stepsize to convert value to index
+        if (final_data[roc_index[i_roc]][calib / calib_step][trim_toa / trim_toa_step][ch]> 0.6) {
+          threshold_points.push_back({ch, calib, trim_toa, i_roc});
+          //calib_vals.push_back(calib);
           break;
         }
       }
     }
   }
+}
 
-  pflib_log(info) << "got threshold points, getting fit parameters";
+pflib_log(trace) << "Completed Assigning Threshold Values";
+//int calib_med = pflib::utility::median(calib_vals) ;
+int calib_tgt = 40 ;  //base this value around what your target calib value is for the highrange
 
-  // get vector of data points for each channel.
+
+// get vector of data points for each channel.
+std::map<int, std::array<int, 72>> target;
+for (int i_roc : tgt-> roc_ids()) {
+  std::vector<uint64_t> avg_toa_vals; //For the averaging for the channels that are missing data, it is designed to have them be calculated per
+                                      //ROC, as I have found that the behaviors of the data for each ROC seems to be unique to each chip
   for (int ch{0}; ch < 72; ch++) {
     std::vector<double> calib;
     std::vector<double> trim_toa;
 
     for (const auto& row : threshold_points) {
+      if (row[3] == i_roc){
       if (row[0] == ch) {
         calib.push_back(row[1]);
         trim_toa.push_back(row[2]);
+       }
       }
     }
+    if (calib.size() < 2) { //Code made to remove the data that was too insignificant
+    std::cout << "Skipping channel " << ch << " due to insufficient points, setting to be middle value (" << calib.size() << ")" << std::endl;
+    //Need to have this averaging because some of the channels simply dont capture any data at all (some of them are dead, but those dont factor into calculating this average)
+    target[roc_index[i_roc]][ch] = static_cast<int>(-1); //Identify these dead channels as 0, which is a value none of the working channels produce
+    continue;
+    }
+    //std::cout << "x_vals size: " << calib.size() << ", y_vals size: " << trim_toa.size() << std::endl;
+    auto [slope, intercept] = siegel_regression(calib, trim_toa);  //applies the Siegel regression to your data
+    pflib_log(trace) << "Slope value was found to be = " << slope << "\n";
+    int optimal_trim_val_round =  static_cast<int>(std::round(calib_tgt * slope + intercept));
+    pflib_log(trace) << "Appended optimal_trim_val =" << optimal_trim_val_round;
+    int optimal_trim_val_clam = std::clamp(optimal_trim_val_round, 0, 63);
+    int optimal_trim_val =  static_cast<uint64_t>(std::round(optimal_trim_val_clam)); //apply settings to make the optimal trim more reasonable
+    target[roc_index[i_roc]][ch] = static_cast<uint64_t>(optimal_trim_val);
+    avg_toa_vals.push_back(optimal_trim_val); //append data to be averaged
+ }
 
-    if (calib.empty() || trim_toa.empty()) {
-      std::cout << "skipping channel " << ch << " due to empty data.\n";
-      continue;
+int sum = std::reduce(avg_toa_vals.begin(), avg_toa_vals.end(), 0);
+int average = std::round(std::reduce(avg_toa_vals.begin(), avg_toa_vals.end(), 0.0) / avg_toa_vals.size());
+
+for (int ch = 0; ch < 72; ch++) {
+    if (target[roc_index[i_roc]][ch] == -1) {
+        target[roc_index[i_roc]][ch] = average;
+    }
     }
 
-    std::cout << "about to do linear regression" << std::endl;
-    std::cout << "x_vals size: " << calib.size()
-              << ", y_vals size: " << trim_toa.size() << std::endl;
-    auto [slope, intercept] = siegel_regression(calib, trim_toa);
-    std::cout << "did regression" << std::endl;
-  }
-
-  // now, write the settings, but this is just placeholder for now!
-
-  std::map<std::string, std::map<std::string, uint64_t>> settings;
-
-  std::array<int, 2> targetss = {0, 0};
-  for (int i_link{0}; i_link < 2; i_link++) {
-    std::string page{pflib::utility::string_format("CH_%d", i_link)};
-    settings[page]["CALIB"] = targetss[i_link];
-  }
-
-  return settings;
+pflib_log(trace) << "did the averaging and found it to be:" << average;
+pflib_log(info) << "Completed Regression";
 }
 
+pflib_log(trace) << "writing TRIM_TOA settings";
+
+std::map<int, std::map<std::string, std::map<std::string, uint64_t>>> settings;
+ for (int i_roc : tgt-> roc_ids()) {
+  for (int ch{0}; ch < 72; ch++) {
+    std::string page{pflib::utility::string_format("CH_%d", ch)};
+    settings[i_roc][page]["TRIM_TOA"] = target[roc_index[i_roc]][ch];
+}
+}
+  return settings;
+}
 }  // namespace pflib::algorithm

--- a/app/tool/algorithm/trim_toa_scan.h
+++ b/app/tool/algorithm/trim_toa_scan.h
@@ -15,9 +15,9 @@ namespace pflib::algorithm {
  *
  * @note Only functional for single-ROC targets
  */
-//int i_roc, const pflib::packing::SingleECONDRocErxMapping& mapping,
+// int i_roc, const pflib::packing::SingleECONDRocErxMapping& mapping,
 
-std::map<int , std::map<std::string, std::map<std::string, uint64_t>>> trim_toa_scan(
-    Target* tgt);
+std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>
+trim_toa_scan(Target* tgt);
 
 }  // namespace pflib::algorithm

--- a/app/tool/algorithm/trim_toa_scan.h
+++ b/app/tool/algorithm/trim_toa_scan.h
@@ -15,7 +15,9 @@ namespace pflib::algorithm {
  *
  * @note Only functional for single-ROC targets
  */
-std::map<std::string, std::map<std::string, uint64_t>> trim_toa_scan(
-    Target* tgt, ROC roc);
+//int i_roc, const pflib::packing::SingleECONDRocErxMapping& mapping,
+
+std::map<int , std::map<std::string, std::map<std::string, uint64_t>>> trim_toa_scan(
+    Target* tgt);
 
 }  // namespace pflib::algorithm

--- a/app/tool/tasks/local_pedestal_level.cxx
+++ b/app/tool/tasks/local_pedestal_level.cxx
@@ -24,12 +24,12 @@ void local_pedestal_level(Target* tgt) {
     std::string iroc_str{std::to_string(iroc)};
 
     if (pftool::readline_bool("View deduced settings for ROC" + iroc_str + "? ",
-                              true)) {
+                              false)) {
       std::cout << out.c_str() << std::endl;
     }
 
     if (pftool::readline_bool("Apply settings to ROC" + iroc_str + "? ",
-                              false)) {
+                              true)) {
       tgt->roc(iroc).applyParameters(parameters);
     }
 

--- a/app/tool/tasks/tasks.cxx
+++ b/app/tool/tasks/tasks.cxx
@@ -7,6 +7,7 @@
 #include "../pftool.h"
 #include "channel_wise_calib_scan.h"
 #include "charge_timescan.h"
+#include "examine_phase.h"
 #include "expert/scan_orbit.h"
 #include "gen_scan.h"
 #include "get_lpgbt_temps.h"
@@ -27,6 +28,7 @@
 #include "trim_inv_dacb_scan.h"
 #include "trim_toa_scan.h"
 #include "vref_2d_scan.h"
+#include "bx_toa_scan.h"
 #include "vt50_scan.h"
 
 namespace {
@@ -68,6 +70,7 @@ auto menu_tasks =
                local_pedestal_level)
         ->line("TOA_VREF_SCAN", "scan over VREF parameters for TOA calibration",
                toa_vref_scan)
+        //->line("EXAMINE_PHASE", "scan over phase parameters", examine_phase)
         ->line("TOA_SCAN",
                "just does that bro (changes CALIB while saving only TOA)",
                toa_scan)
@@ -75,7 +78,11 @@ auto menu_tasks =
                "scan over VREF and TRIM parameters for TOT calibration",
                tot_vref_scan)
         ->line("TRIM_TOA_SCAN",
-               "calibrate TRIM_TOA parameters for each channel", trim_toa_scan);
+               "calibrate TRIM_TOA parameters for each channel",
+               trim_toa_scan)
+        ->line("BX_TOA_SCAN",
+               "finds optimal bx value for each link",
+               bx_toa_scan);
 
 auto menu_expert_tasks =
     menu_tasks->submenu("EXPERT", "low-level but complicated tasks")

--- a/app/tool/tasks/tasks.cxx
+++ b/app/tool/tasks/tasks.cxx
@@ -5,6 +5,7 @@
  */
 
 #include "../pftool.h"
+#include "bx_toa_scan.h"
 #include "channel_wise_calib_scan.h"
 #include "charge_timescan.h"
 #include "examine_phase.h"
@@ -28,7 +29,6 @@
 #include "trim_inv_dacb_scan.h"
 #include "trim_toa_scan.h"
 #include "vref_2d_scan.h"
-#include "bx_toa_scan.h"
 #include "vt50_scan.h"
 
 namespace {
@@ -78,10 +78,8 @@ auto menu_tasks =
                "scan over VREF and TRIM parameters for TOT calibration",
                tot_vref_scan)
         ->line("TRIM_TOA_SCAN",
-               "calibrate TRIM_TOA parameters for each channel",
-               trim_toa_scan)
-        ->line("BX_TOA_SCAN",
-               "finds optimal bx value for each link",
+               "calibrate TRIM_TOA parameters for each channel", trim_toa_scan)
+        ->line("BX_TOA_SCAN", "finds optimal bx value for each link",
                bx_toa_scan);
 
 auto menu_expert_tasks =

--- a/app/tool/tasks/toa_vref_scan.cxx
+++ b/app/tool/tasks/toa_vref_scan.cxx
@@ -1,42 +1,45 @@
 #include "toa_vref_scan.h"
+
 #include <yaml-cpp/yaml.h>
+
 #include <fstream>
+
 #include "../algorithm/toa_vref_scan.h"
 
 void toa_vref_scan(Target* tgt) {
   auto settings = pflib::algorithm::toa_vref_scan(tgt);
   for (const auto& [i_roc, parameters] : settings) {
-  auto roc{tgt->roc(i_roc)};
-  YAML::Emitter out;
-  out << YAML::BeginMap;
-  for (const auto& page : parameters) {
-    out << YAML::Key << page.first;
-    out << YAML::Value << YAML::BeginMap;
-    for (const auto& param : page.second) {
-      out << YAML::Key << param.first << YAML::Value << param.second;
+    auto roc{tgt->roc(i_roc)};
+    YAML::Emitter out;
+    out << YAML::BeginMap;
+    for (const auto& page : parameters) {
+      out << YAML::Key << page.first;
+      out << YAML::Value << YAML::BeginMap;
+      for (const auto& param : page.second) {
+        out << YAML::Key << param.first << YAML::Value << param.second;
+      }
+      out << YAML::EndMap;
     }
     out << YAML::EndMap;
-  }
-  out << YAML::EndMap;
 
-  if (pftool::readline_bool("View deduced settings? ", true)) {
-    std::cout << out.c_str() << std::endl;
-  }
-
-  if (pftool::readline_bool("Apply settings to the chip? ", true)) {
-    roc.applyParameters(parameters);
-  }
-
-  if (pftool::readline_bool("Save settings to a file? ", false)) {
-    std::string fname = pftool::readline_path(
-        "toa-vref-scan-" + std::to_string(pftool::state.iroc) + "-settings",
-        ".yaml");
-
-    std::ofstream f{fname};
-    if (not f.is_open()) {
-      PFEXCEPTION_RAISE("File", "Unable to open file " + fname + ".");
+    if (pftool::readline_bool("View deduced settings? ", true)) {
+      std::cout << out.c_str() << std::endl;
     }
-    f << out.c_str() << std::endl;
+
+    if (pftool::readline_bool("Apply settings to the chip? ", true)) {
+      roc.applyParameters(parameters);
+    }
+
+    if (pftool::readline_bool("Save settings to a file? ", false)) {
+      std::string fname = pftool::readline_path(
+          "toa-vref-scan-" + std::to_string(pftool::state.iroc) + "-settings",
+          ".yaml");
+
+      std::ofstream f{fname};
+      if (not f.is_open()) {
+        PFEXCEPTION_RAISE("File", "Unable to open file " + fname + ".");
+      }
+      f << out.c_str() << std::endl;
+    }
   }
-}
 }

--- a/app/tool/tasks/toa_vref_scan.cxx
+++ b/app/tool/tasks/toa_vref_scan.cxx
@@ -1,17 +1,15 @@
 #include "toa_vref_scan.h"
-
 #include <yaml-cpp/yaml.h>
-
 #include <fstream>
-
 #include "../algorithm/toa_vref_scan.h"
 
 void toa_vref_scan(Target* tgt) {
-  auto roc{tgt->roc(pftool::state.iroc)};
-  auto settings = pflib::algorithm::toa_vref_scan(tgt, roc);
+  auto settings = pflib::algorithm::toa_vref_scan(tgt);
+  for (const auto& [i_roc, parameters] : settings) {
+  auto roc{tgt->roc(i_roc)};
   YAML::Emitter out;
   out << YAML::BeginMap;
-  for (const auto& page : settings) {
+  for (const auto& page : parameters) {
     out << YAML::Key << page.first;
     out << YAML::Value << YAML::BeginMap;
     for (const auto& param : page.second) {
@@ -26,7 +24,7 @@ void toa_vref_scan(Target* tgt) {
   }
 
   if (pftool::readline_bool("Apply settings to the chip? ", true)) {
-    roc.applyParameters(settings);
+    roc.applyParameters(parameters);
   }
 
   if (pftool::readline_bool("Save settings to a file? ", false)) {
@@ -40,4 +38,5 @@ void toa_vref_scan(Target* tgt) {
     }
     f << out.c_str() << std::endl;
   }
+}
 }

--- a/app/tool/tasks/trim_toa_scan.cxx
+++ b/app/tool/tasks/trim_toa_scan.cxx
@@ -1,17 +1,15 @@
 #include "trim_toa_scan.h"
-
 #include <yaml-cpp/yaml.h>
-
 #include <fstream>
-
 #include "../algorithm/trim_toa_scan.h"
 
 void trim_toa_scan(Target* tgt) {
-  auto roc{tgt->roc(pftool::state.iroc)};
-  auto settings = pflib::algorithm::trim_toa_scan(tgt, roc);
+  auto settings = pflib::algorithm::trim_toa_scan(tgt);
+  for (const auto& [i_roc, parameters] : settings) {
+  auto roc{tgt->roc(i_roc)};
   YAML::Emitter out;
   out << YAML::BeginMap;
-  for (const auto& page : settings) {
+  for (const auto& page : parameters) {
     out << YAML::Key << page.first;
     out << YAML::Value << YAML::BeginMap;
     for (const auto& param : page.second) {
@@ -26,7 +24,7 @@ void trim_toa_scan(Target* tgt) {
   }
 
   if (pftool::readline_bool("Apply settings to the chip? ", true)) {
-    roc.applyParameters(settings);
+    roc.applyParameters(parameters);
   }
 
   if (pftool::readline_bool("Save settings to a file? ", false)) {
@@ -40,4 +38,5 @@ void trim_toa_scan(Target* tgt) {
     }
     f << out.c_str() << std::endl;
   }
+}
 }

--- a/app/tool/tasks/trim_toa_scan.cxx
+++ b/app/tool/tasks/trim_toa_scan.cxx
@@ -1,42 +1,45 @@
 #include "trim_toa_scan.h"
+
 #include <yaml-cpp/yaml.h>
+
 #include <fstream>
+
 #include "../algorithm/trim_toa_scan.h"
 
 void trim_toa_scan(Target* tgt) {
   auto settings = pflib::algorithm::trim_toa_scan(tgt);
   for (const auto& [i_roc, parameters] : settings) {
-  auto roc{tgt->roc(i_roc)};
-  YAML::Emitter out;
-  out << YAML::BeginMap;
-  for (const auto& page : parameters) {
-    out << YAML::Key << page.first;
-    out << YAML::Value << YAML::BeginMap;
-    for (const auto& param : page.second) {
-      out << YAML::Key << param.first << YAML::Value << param.second;
+    auto roc{tgt->roc(i_roc)};
+    YAML::Emitter out;
+    out << YAML::BeginMap;
+    for (const auto& page : parameters) {
+      out << YAML::Key << page.first;
+      out << YAML::Value << YAML::BeginMap;
+      for (const auto& param : page.second) {
+        out << YAML::Key << param.first << YAML::Value << param.second;
+      }
+      out << YAML::EndMap;
     }
     out << YAML::EndMap;
-  }
-  out << YAML::EndMap;
 
-  if (pftool::readline_bool("View deduced settings? ", true)) {
-    std::cout << out.c_str() << std::endl;
-  }
-
-  if (pftool::readline_bool("Apply settings to the chip? ", true)) {
-    roc.applyParameters(parameters);
-  }
-
-  if (pftool::readline_bool("Save settings to a file? ", false)) {
-    std::string fname = pftool::readline_path(
-        "trim-toa-scan-" + std::to_string(pftool::state.iroc) + "-settings",
-        ".yaml");
-
-    std::ofstream f{fname};
-    if (not f.is_open()) {
-      PFEXCEPTION_RAISE("File", "Unable to open file " + fname + ".");
+    if (pftool::readline_bool("View deduced settings? ", true)) {
+      std::cout << out.c_str() << std::endl;
     }
-    f << out.c_str() << std::endl;
+
+    if (pftool::readline_bool("Apply settings to the chip? ", true)) {
+      roc.applyParameters(parameters);
+    }
+
+    if (pftool::readline_bool("Save settings to a file? ", false)) {
+      std::string fname = pftool::readline_path(
+          "trim-toa-scan-" + std::to_string(pftool::state.iroc) + "-settings",
+          ".yaml");
+
+      std::ofstream f{fname};
+      if (not f.is_open()) {
+        PFEXCEPTION_RAISE("File", "Unable to open file " + fname + ".");
+      }
+      f << out.c_str() << std::endl;
+    }
   }
-}
 }

--- a/build/toa_graph.py
+++ b/build/toa_graph.py
@@ -1,0 +1,51 @@
+import os
+import argparse
+from pathlib import Path
+
+import pandas as pd
+import matplotlib.pyplot as plt
+import matplotlib as mpl
+import numpy as np
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('data', type=Path, help='decoded CSV file to analyze')
+parser.add_argument('ch', type=int, help='channel to analyze')
+#only takes data from roc = 1
+args = parser.parse_args()
+
+data_raw = pd.read_csv(args.data, header = None)
+
+ch = args.ch
+
+trim_toa = []
+calib = []
+efficiency = []
+
+
+print(data_raw.head())
+for _, row in data_raw.iterrows():
+  #if row[0] == 0:
+    if (row[1] == ch):
+      trim_toa.append(row[2])
+      calib.append(row[3])
+      efficiency.append(row[4])
+ #else:
+  #   continue
+
+
+# set up the figure and Axes
+fig = plt.figure(figsize=(8, 3))
+ax = fig.add_subplot(projection='3d')
+# 3. Plot the points (color mapped by their Z values)
+scatter = ax.scatter(calib, trim_toa, efficiency, c=efficiency, cmap='viridis', s=40, edgecolors='w')
+
+# 4. Add labels, a colorbar, and titles
+ax.set_xlabel('Calib')
+ax.set_ylabel('Trim_toa')
+ax.set_zlabel('Efficiency')
+ax.set_title(f'Plot of Efficiency {ch}' )
+fig.colorbar(scatter, ax=ax, label='Z Depth')
+
+# 5. Display the window
+plt.show()

--- a/include/pflib/Exception.h
+++ b/include/pflib/Exception.h
@@ -26,8 +26,8 @@ class Exception : public std::exception {
    * @param line Line in the source code where the exception occurred.
    * @param function Function in which the exception occurred.
    */
-  Exception(const std::string &name, const std::string &message,
-            const std::string &module, int line, const std::string &function)
+  Exception(const std::string& name, const std::string& message,
+            const std::string& module, int line, const std::string& function)
       : name_{name},
         message_{message},
         module_{module},
@@ -43,25 +43,25 @@ class Exception : public std::exception {
    * Get the name of the exception.
    * @return The name of the exception.
    */
-  const std::string &name() const throw() { return name_; }
+  const std::string& name() const throw() { return name_; }
 
   /**
    * Get the message of the exception.
    * @return The message of the exception.
    */
-  const std::string &message() const throw() { return message_; }
+  const std::string& message() const throw() { return message_; }
 
   /**
    * Get the source filename where the exception occurred.
    * @return The source filename where the exception occurred.
    */
-  const std::string &module() const throw() { return module_; }
+  const std::string& module() const throw() { return module_; }
 
   /**
    * Get the function name where the exception occurred.
    * @return The function name where the exception occurred.
    */
-  const std::string &function() const throw() { return function_; }
+  const std::string& function() const throw() { return function_; }
 
   /**
    * Get the source line number where the exception occurred.
@@ -73,7 +73,7 @@ class Exception : public std::exception {
    * The error message.
    * @return The error message.
    */
-  virtual const char *what() const throw() { return message_.c_str(); }
+  virtual const char* what() const throw() { return message_.c_str(); }
 
  private:
   /** Exception name. */

--- a/src/pflib/packing/ECONDEventPacket.cxx
+++ b/src/pflib/packing/ECONDEventPacket.cxx
@@ -11,7 +11,7 @@
 namespace pflib::packing {
 
 std::size_t ECONDEventPacket::unpack_link_subpacket(std::span<uint32_t> data,
-                                                    DAQLinkFrame &link,
+                                                    DAQLinkFrame& link,
                                                     bool passthrough) {
   pflib_log(trace) << "link header " << hex(data[0]);
   // sub-packet start
@@ -56,7 +56,7 @@ std::size_t ECONDEventPacket::unpack_link_subpacket(std::span<uint32_t> data,
                      << " i_ch=" << i_chan;
 
     // deduce a reference to the channel that we are unpacking
-    Sample *ch = &(link.calib);
+    Sample* ch = &(link.calib);
     if (i_chan < 18) {
       ch = &(link.channels[i_chan]);
     } else if (i_chan > 18) {
@@ -327,7 +327,7 @@ void ECONDEventPacket::from(std::span<uint32_t> data) {
   }
 
   std::size_t offset{2};
-  for (auto &link : links) {
+  for (auto& link : links) {
     offset += unpack_link_subpacket(data.subspan(offset), link, passthrough);
     link.bx = bx;
     link.event = l1a;


### PR DESCRIPTION
Updated TRIM_TOA_SCAN to:
-Fixed issue in the intercepts calculation of the siegel_regression function.
-Reorganized the loops in this command so that the function loops in the following order:
'''
i_roc 
--ch
----trim_toa
------CALIB
'''
-Also now can function for multiple ROCs being attached.
-Updated to stop after the first event that is found for each channel that triggers this "high efficiency threshold" (we want to see when the toa starts firing very actively, not just a fluctuation). Also this is all the data that we are using anyways so it is not causing the regression to be worse at all. 
-Changed efficiency threshold to be when > 95% of the runs return a non-zero TOA value, to make the slope more accurate to where TOA is fully firing.
-Added portion that saves acquired toa data to a csv file to be analyzed later (using toa_graph.py)
-Decided to set a target calib value of 75, may change in the future but I have found that 70-110 is around when toa starts to trigger depending on the channel.
-Added skip functionality that skips over a channel if it find that the channel had TOA trigger no times over any of my data collection. This channel has the average TRIM_TOA value of channels on its ROC applied to it. If it is truly not firing this should not affect anything negatively, so this is our best guess of what could be applied to it.
-Applied a clamp to the max and min value of TRIM_TOA that is being applied, as to not overload the register with an int that is too large for it to be stored

Added in the toa_graph.py file which can be used with the format:

'''python toa_graph.py toa_efficiencies.csv [i_roc]  [ch]'''

This file is intended to be good way to visualize if your data is actually following a linear fit, also can be useful to show if your data is not agreeing with the general "sharp S-curve" shape that we are expecting from TOA efficiency as calib increases. PLEASE NOTE: due to the new portion of the code that breaks after the first high efficiency TRIM_TOA value is found it will be visualized as a line of higher dots that then goes back down to 0, this just means that the scan stopped for this value. You can get far more complete understanding of how that channel is behaving if you remove line 173 of trim_toa_scan.cxx and then do a scan, however this will take significantly longer. 


<img width="895" height="806" alt="Figure_1" src="https://github.com/user-attachments/assets/758be891-50d3-4093-b445-aa2e20a279c8" />

Added changes to the toa_vref scan to apply a TRIM_TOA value of 63 to so that its TOA_VREF value doesn't cause the collected data to dip back into the pedestal range once a TRIM_TOA value is applied. Also applied changes to the CHANNEL_WIDE_CALIB_SCAN to make it more efficient to run, by removing scanning over PHASE_CX and multiple bx values as this did not seem to affect any of the data created.
