### PR TITLE
various leftover bittware developments

### DIFF
--- a/app/tool/tasks/expert/scan_orbit.cxx
+++ b/app/tool/tasks/expert/scan_orbit.cxx
@@ -40,6 +40,8 @@ void scan_orbit(Target* tgt) {
     file_output.open(output_filepath);
   }
 
+  bool ignore_disabled_links = pftool::readline_bool(
+      "Ignore links that are disabled? ", true);
   bool show_raw_snapshot = pftool::readline_bool(
       "Show raw snapshot (Y) or shift by align select (N)?", false);
   bool skip_normal_idles =
@@ -60,8 +62,14 @@ void scan_orbit(Target* tgt) {
   manual_snaps["ALIGNER"]["GLOBAL_I2C_SNAPSHOT_EN"] = 1;
   manual_snaps["ALIGNER"]["GLOBAL_SNAPSHOT_ARM"] = 0;
   manual_snaps["ALIGNER"]["GLOBAL_SNAPSHOT_EN"] = 1;
+  std::array<bool, 12> link_enabled;
   for (int i_econ_ch{0}; i_econ_ch < 12; i_econ_ch++) {
     auto prefix{std::to_string(i_econ_ch)};
+    if (econ.readParameter("ERX", prefix+"_ENABLE") == 0 and ignore_disabled_links) {
+      link_enabled[i_econ_ch] = false;
+      continue;
+    }
+    link_enabled[i_econ_ch] = true;
     manual_snaps["CHALIGNER"][prefix + "_PER_CH_ALIGN_EN"] = 0;
     manual_snaps["ERX"][prefix + "_ENABLE"] = 1;
   }
@@ -74,6 +82,7 @@ void scan_orbit(Target* tgt) {
   std::map<int, int> select;
   std::cout << "select shifts: { ";
   for (int ch{0}; ch < 12; ch++) {
+    if (not link_enabled[ch]) continue;
     select[ch] = econ.getValues(CHALIGNER_RO[ch] + 0x1, 1)[0];
     if (ch > 0) {
       std::cout << ", ";
@@ -101,12 +110,19 @@ void scan_orbit(Target* tgt) {
   std::cout << "daq event occupancy: " << tgt->daq().getEventOccupancy()
             << std::endl;
 
-  static const char* header{
-      "t_snapshot,daq_event_occupancy,00,01,02,03,04,05,06,07,08,09,10,11\n"};
+  std::stringstream header;
+  header << "t_snapshot,daq_event_occupancy";
+  for (int erx{0}; erx < link_enabled.size(); erx++) {
+    if (link_enabled[erx]) {
+      header << "," << erx;
+    }
+  }
+  header << "\n";
+
   if (to_screen) {
-    std::cout << header;
+    std::cout << header.str();
   } else {
-    file_output << header;
+    file_output << header.str();
   }
 
   std::vector<uint8_t> aligner_flags(1);
@@ -130,6 +146,7 @@ void scan_orbit(Target* tgt) {
     row << std::setw(4) << t_snapshot << ',' << tgt->daq().getEventOccupancy();
     bool should_print{not skip_normal_idles};
     for (int ch{0}; ch < 12; ch++) {
+      if (not link_enabled[ch]) continue;
       boost::multiprecision::uint256_t snapshot{0};
       // have to read in 8byte chunks
       for (int i_snp{0}; i_snp < 3; i_snp++) {

--- a/app/tool/tasks/expert/scan_orbit.cxx
+++ b/app/tool/tasks/expert/scan_orbit.cxx
@@ -40,8 +40,8 @@ void scan_orbit(Target* tgt) {
     file_output.open(output_filepath);
   }
 
-  bool ignore_disabled_links = pftool::readline_bool(
-      "Ignore links that are disabled? ", true);
+  bool ignore_disabled_links =
+      pftool::readline_bool("Ignore links that are disabled? ", true);
   bool show_raw_snapshot = pftool::readline_bool(
       "Show raw snapshot (Y) or shift by align select (N)?", false);
   bool skip_normal_idles =
@@ -65,7 +65,8 @@ void scan_orbit(Target* tgt) {
   std::array<bool, 12> link_enabled;
   for (int i_econ_ch{0}; i_econ_ch < 12; i_econ_ch++) {
     auto prefix{std::to_string(i_econ_ch)};
-    if (econ.readParameter("ERX", prefix+"_ENABLE") == 0 and ignore_disabled_links) {
+    if (econ.readParameter("ERX", prefix + "_ENABLE") == 0 and
+        ignore_disabled_links) {
       link_enabled[i_econ_ch] = false;
       continue;
     }

--- a/config/econ/econd_ecal_smm_umn_init.yaml
+++ b/config/econ/econd_ecal_smm_umn_init.yaml
@@ -28,8 +28,12 @@ ERX:
 ETX:
   0_INVERT_DATA: 0
 ELINKPROCESSORS:
-  GLOBAL_V_RECONSTRUCT_THRESH: 0 # number of erxs that should have the same 
-  GLOBAL_VETO_PASS_FAIL: 0xFFFF # select all of the possible combinations of event status bits (E, HT, EBO, and M) as ok
+  # number of erxs that should have the same EBO to build event
+  GLOBAL_V_RECONSTRUCT_THRESH: 0 
+  # select all of the possible combinations of event status bits (E, HT, EBO, and M) as ok
+  GLOBAL_VETO_PASS_FAIL: 0xFFFF
+  # ignore all EBO mismatch errors since that is regularly failing right now
+  GLOBAL_ERX_MASK_EBO: 0xFFF
 FORMATTERBUFFER:
   GLOBAL_ACTIVE_ETXS: 1 # only 1 active etx
   GLOBAL_IDLE_PATTERN: 0x1277cc # must match what's in ECON-lpGBT align code

--- a/src/pflib/bittware/bittware_daq.cxx
+++ b/src/pflib/bittware/bittware_daq.cxx
@@ -48,9 +48,9 @@ HcalBackplaneBW_Capture::HcalBackplaneBW_Capture(const char* dev)
     : DAQ(1),
       capture_(BASE_ADDRESS_CAPTURE0, dev),
       the_log_{logging::get("bw_capture")} {
-  auto hw_type = capture_.get_hardware_type();
-  auto fw_vers = capture_.get_firmware_version();
-  auto header_marker = capture_.read(ADDR_HEADER_MARKER);
+  uint16_t hw_type = capture_.get_hardware_type();
+  uint16_t fw_vers = capture_.get_firmware_version();
+  uint16_t header_marker = capture_.read(ADDR_HEADER_MARKER);
   pflib_log(info) << "HW Type: " << hex(hw_type)
                   << " FW Version: " << hex(fw_vers)
                   << " Header Mark: " << hex(header_marker);

--- a/src/pflib/packing/ECONDEventPacket.cxx
+++ b/src/pflib/packing/ECONDEventPacket.cxx
@@ -10,6 +10,34 @@
 
 namespace pflib::packing {
 
+class PrintLinkStatBits {
+  const uint32_t& stat_;
+  static const std::array<const char*, 3> BIT_NAMES;
+ public:
+  PrintLinkStatBits(const uint32_t& stat)
+    : stat_{stat} {}
+  friend inline std::ostream& operator<<(std::ostream& o,
+                                         const PrintLinkStatBits& self) {
+    std::bitset<3> bits = self.stat_;
+    o << "bits 0b" << bits << " -> [";
+    for (std::size_t i{0}; i < 3; i++) {
+      if (!bits.test(i)) {
+        o << " " << BIT_NAMES[i];
+      }
+    }
+    o << " ] mismatched";
+    return o;
+  }
+};
+
+/**
+ * ECON-D Manual: MSB is HT match status, then EBO, then CRC
+ * index 0 is LSB, so we invert this order here.
+ */
+const std::array<const char*, 3> PrintLinkStatBits::BIT_NAMES = {
+  "CRC", "EBO", "HT"
+};
+
 std::size_t ECONDEventPacket::unpack_link_subpacket(std::span<uint32_t> data,
                                                     DAQLinkFrame& link,
                                                     bool passthrough) {
@@ -18,7 +46,7 @@ std::size_t ECONDEventPacket::unpack_link_subpacket(std::span<uint32_t> data,
   uint32_t stat = ((data[0] >> 29) & mask<3>);
   link.corruption[0] = (stat != 0b111);  // all ones is GOOD
   if (link.corruption[0]) {
-    pflib_log(warn) << "bad subpacket checks " << std::bitset<3>(stat);
+    pflib_log(warn) << "bad link Stat " << PrintLinkStatBits(stat);
   }
   uint32_t ham = ((data[0] >> 26) & mask<3>);
   bool is_empty = ((data[0] >> 25) & mask<1>) == 1;
@@ -36,7 +64,8 @@ std::size_t ECONDEventPacket::unpack_link_subpacket(std::span<uint32_t> data,
     // E=0 (false) means none of the 37 channels passed zero suppression
     // E=1 (true) means the unmasked Stat error bits caused the sub-packet to be
     // suppressed
-    pflib_log(trace) << "is empty, E=" << error_caused_empty;
+    pflib_log(trace) << "is empty, did unmasked Stat error bits cause empty? = "
+                     << error_caused_empty;
     return length;
   }
 

--- a/src/pflib/packing/ECONDEventPacket.cxx
+++ b/src/pflib/packing/ECONDEventPacket.cxx
@@ -13,9 +13,9 @@ namespace pflib::packing {
 class PrintLinkStatBits {
   const uint32_t& stat_;
   static const std::array<const char*, 3> BIT_NAMES;
+
  public:
-  PrintLinkStatBits(const uint32_t& stat)
-    : stat_{stat} {}
+  PrintLinkStatBits(const uint32_t& stat) : stat_{stat} {}
   friend inline std::ostream& operator<<(std::ostream& o,
                                          const PrintLinkStatBits& self) {
     std::bitset<3> bits = self.stat_;
@@ -34,9 +34,8 @@ class PrintLinkStatBits {
  * ECON-D Manual: MSB is HT match status, then EBO, then CRC
  * index 0 is LSB, so we invert this order here.
  */
-const std::array<const char*, 3> PrintLinkStatBits::BIT_NAMES = {
-  "CRC", "EBO", "HT"
-};
+const std::array<const char*, 3> PrintLinkStatBits::BIT_NAMES = {"CRC", "EBO",
+                                                                 "HT"};
 
 std::size_t ECONDEventPacket::unpack_link_subpacket(std::span<uint32_t> data,
                                                     DAQLinkFrame& link,


### PR DESCRIPTION
- ignore links that are disabled when doing scan orbit
- better decoding printouts surrounding ebo mismatch
- include mask_ebo in example EcalSMM ECON-D config