### PR TITLE
patch zcu opto fiber link error reporting (and injection)

### DIFF
--- a/app/tool/opto.cxx
+++ b/app/tool/opto.cxx
@@ -89,7 +89,6 @@ void opto(const std::string& cmd, Target* target) {
     printf("  %-20s : %.3f MHz (0x%04x)\n", i.first.c_str(), i.second / 1e3,
            i.second);
   }
-  
 }
 
 namespace {

--- a/app/tool/opto.cxx
+++ b/app/tool/opto.cxx
@@ -53,24 +53,6 @@ void opto(const std::string& cmd, Target* target) {
     }
   }
 
-  if (cmd == "FULLSTATUS") {
-    static const uint16_t ULDATASOURCE0 = 0x128;
-    printf("Polarity -- TX: %d  RX: %d\n", olink.get_tx_polarity(),
-           olink.get_rx_polarity());
-    pflib::lpGBT lpgbt{target->get_opto_link(olink_name).lpgbt_transport()};
-    std::map<std::string, uint32_t> info;
-    info = olink.opto_status();
-    printf("Optical status:\n");
-    for (auto i : info) {
-      printf("  %-20s : 0x%04x\n", i.first.c_str(), i.second);
-    }
-    info = olink.opto_rates();
-    printf("Optical rates:\n");
-    for (auto i : info) {
-      printf("  %-20s : %.3f MHz (0x%04x)\n", i.first.c_str(), i.second / 1e3,
-             i.second);
-    }
-  }
   if (cmd == "SOFTRESET") {
     olink.soft_reset_link();
   }
@@ -86,9 +68,28 @@ void opto(const std::string& cmd, Target* target) {
     change = pftool::readline_bool("Change RX polarity? ", false);
     if (change) olink.set_rx_polarity(!olink.get_tx_polarity());
   }
+
   if (cmd == "LINKTRICK") {
     olink.run_linktrick();
   }
+
+  printf("Olink: %s\n", olink_name.c_str());
+  printf("Polarity -- TX: %d  RX: %d\n", olink.get_tx_polarity(),
+         olink.get_rx_polarity());
+  pflib::lpGBT lpgbt{target->get_opto_link(olink_name).lpgbt_transport()};
+  std::map<std::string, uint32_t> info;
+  info = olink.opto_status();
+  printf("Optical status:\n");
+  for (auto i : info) {
+    printf("  %-20s : 0x%04x\n", i.first.c_str(), i.second);
+  }
+  info = olink.opto_rates();
+  printf("Optical rates:\n");
+  for (auto i : info) {
+    printf("  %-20s : %.3f MHz (0x%04x)\n", i.first.c_str(), i.second / 1e3,
+           i.second);
+  }
+  
 }
 
 namespace {

--- a/app/tool/opto.cxx
+++ b/app/tool/opto.cxx
@@ -19,7 +19,11 @@ void opto_render(Target* tgt) {
  *
  * ## Commands
  * - FULLSTATUS : printout status of the optical links
- * - RESET : call reset_link on the optical links
+ *   this status printout is run after all of the other commands as well
+ * - CHOOSE : pick DAQ or TRG optical fiber to focus on
+ * - INJECT_ERROR : zcu only, attempt to inject an error to test decoding error
+ * - SOFTRESET : call OptoLink::soft_reset_link
+ * - RESET : call OptoLink::reset_link on the optical links
  * - POLARITY : change the polarity of the optical links
  * - LINKTRICK : try a simple trick to re-align the optical links
  */
@@ -41,12 +45,11 @@ void opto(const std::string& cmd, Target* target) {
     if (pftool::state.readout_config_is_zcu()) {
       auto& zcuoelinks{
           static_cast<pflib::zcu::OptoElinksZCU&>(target->elinks())};
-      // spamming because it isn't working...
-      for (int i{0}; i < 1000; i++) {
-        zcuoelinks.injectError();
-      }
+      zcuoelinks.injectError();
+      // wait for errors to be included in integration
+      usleep(1000);
     } else {
-      pflib_log(error) << "injecting an error is possible on the ZCU";
+      pflib_log(error) << "injecting an error is only possible on the ZCU";
     }
   }
 

--- a/src/pflib/zcu/zcu_elinks.cxx
+++ b/src/pflib/zcu/zcu_elinks.cxx
@@ -17,14 +17,9 @@ OptoElinksZCU::OptoElinksZCU(lpGBT* lpdaq, lpGBT* lptrig, int itarget)
 }
 
 void OptoElinksZCU::injectError() {
-  /**
-   * @note We at UMN have not bee able to observe this functioning.
-   * It could be an issue with the link error counting firmware
-   * or a bug in the firmware that is supposed to be injecting the error
-   * or a software bug in that we are not poking the correct register
-   * or not waiting long enough after poking.
-   */
-  uiodecoder_.write(6, 0x3);
+  uiodecoder_.write(6, 0xc);
+  usleep(1000);
+  uiodecoder_.write(6, 0x0);
 }
 
 std::vector<uint32_t> OptoElinksZCU::spy(int ilink, bool new_capture) {

--- a/src/pflib/zcu/zcu_optolink.cxx
+++ b/src/pflib/zcu/zcu_optolink.cxx
@@ -177,7 +177,8 @@ std::map<std::string, uint32_t> ZCUOptoLink::opto_rates() {
     static const std::array<const char*, 10> cnames = {
         "DAQ_LINK_WORD",   "TRIG_LINK_WORD", "DAQ_LINK_ERROR",
         "TRIG_LINK_ERROR", "DAQ_LINK_CLOCK", "TRIG_LINK_CLOCK",
-        "CLOCK_40", "AXI_CLK", "DAQ_LINK_FECERR", "TRIG_LINK_FECERR"};
+        "CLOCK_40",        "AXI_CLK",        "DAQ_LINK_FECERR",
+        "TRIG_LINK_FECERR"};
     const int CRATES_OFFSET = 80;
     for (int i = 0; i < cnames.size(); i++) {
       if (i == 2 or i == 3) {

--- a/src/pflib/zcu/zcu_optolink.cxx
+++ b/src/pflib/zcu/zcu_optolink.cxx
@@ -170,10 +170,10 @@ std::map<std::string, uint32_t> ZCUOptoLink::opto_rates() {
       retval[cnames[i]] = coder_.read(CRATES_OFFSET + i);
     }
   } else {
-    static const std::array<const char*, 7> cnames = {
+    static const std::array<const char*, 10> cnames = {
         "DAQ_LINK_WORD",   "TRIG_LINK_WORD", "DAQ_LINK_ERROR",
         "TRIG_LINK_ERROR", "DAQ_LINK_CLOCK", "TRIG_LINK_CLOCK",
-        "CLOCK_40"};
+        "CLOCK_40", "AXI_CLK", "DAQ_LINK_FECERR", "TRIG_LINK_FECERR"};
     const int CRATES_OFFSET = 80;
     for (int i = 0; i < cnames.size(); i++) {
       retval[cnames[i]] = coder_.read(CRATES_OFFSET + i);

--- a/src/pflib/zcu/zcu_optolink.cxx
+++ b/src/pflib/zcu/zcu_optolink.cxx
@@ -138,7 +138,11 @@ std::map<std::string, uint32_t> ZCUOptoLink::opto_status() {
   std::string prefix = "LINK" + std::to_string(ilink_);
   retval[prefix + " READY"] = (val >> (0 * 2 + (ilink_ % 2))) & 0x1;
   retval[prefix + " NOT_IN_RESET"] = (val >> (1 * 2 + (ilink_ % 2))) & 0x1;
+  /**
+   * The LINK_ERRORS are not being incremented when a known error is injected,
+   * so without a future firmware patch, we are electing to ignore them.
   retval[prefix + " LINK_ERRORS"] = coder_.read(4 + (ilink_ % 2)) & 0xFFFFFF;
+   */
 
   /*
   for (int i{0}; i < 80; i++) {
@@ -176,6 +180,12 @@ std::map<std::string, uint32_t> ZCUOptoLink::opto_rates() {
         "CLOCK_40", "AXI_CLK", "DAQ_LINK_FECERR", "TRIG_LINK_FECERR"};
     const int CRATES_OFFSET = 80;
     for (int i = 0; i < cnames.size(); i++) {
+      if (i == 2 or i == 3) {
+        // the LINK_ERROR rates (which are just LINK_NOT_READY counters
+        // integrated over a period of time) don't appear to be deviating
+        // from zero in a useful way so we are NOT including them for now
+        continue;
+      }
       uint32_t val = coder_.read(CRATES_OFFSET + i);
       if (i == 8 or i == 9) {
         // the FECERR rates have a longer integration time

--- a/src/pflib/zcu/zcu_optolink.cxx
+++ b/src/pflib/zcu/zcu_optolink.cxx
@@ -176,7 +176,15 @@ std::map<std::string, uint32_t> ZCUOptoLink::opto_rates() {
         "CLOCK_40", "AXI_CLK", "DAQ_LINK_FECERR", "TRIG_LINK_FECERR"};
     const int CRATES_OFFSET = 80;
     for (int i = 0; i < cnames.size(); i++) {
-      retval[cnames[i]] = coder_.read(CRATES_OFFSET + i);
+      uint32_t val = coder_.read(CRATES_OFFSET + i);
+      if (i == 8 or i == 9) {
+        // the FECERR rates have a longer integration time
+        // and count each error ~8 times
+        // a future FW version will likely remove this 8x counting
+        // so we only divide by the longer integration time here
+        val /= 1000;
+      }
+      retval[cnames[i]] = val;
     }
     /*
     for (int i{CRATES_OFFSET+cnames.size()}; i < 100; i++) {


### PR DESCRIPTION
Changing the value we are writing, registers we are reading, and adding a few more pauses makes the the inject error mechanic work and the link decoding errors observable.