### PR TITLE
update cmake policy, support conda in justfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,8 @@ if (NOT TARGET yaml-cpp::yaml-cpp)
 endif()
 
 # Boost for CRC calculator, Test, Logging, and Python bindings
+cmake_policy(SET CMP0167 NEW)
+cmake_policy(SET CMP0144 NEW)
 find_package(Boost COMPONENTS log unit_test_framework python REQUIRED)
 # Python for Python bindings
 find_package(Python3 COMPONENTS Interpreter Development)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,12 @@ if (NOT TARGET yaml-cpp::yaml-cpp)
 endif()
 
 # Boost for CRC calculator, Test, Logging, and Python bindings
-cmake_policy(SET CMP0167 NEW)
-cmake_policy(SET CMP0144 NEW)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.27)
+  cmake_policy(SET CMP0144 NEW)
+endif()
+if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.30)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 find_package(Boost COMPONENTS log unit_test_framework python REQUIRED)
 # Python for Python bindings
 find_package(Python3 COMPONENTS Interpreter Development)

--- a/justfile
+++ b/justfile
@@ -1,17 +1,24 @@
 help_message := "shared recipes for pflib development
 
 We use 'denv' if there is a denv workspace in the pflib
-directory.
+directory and 'conda run' if there is a '.conda' file
+specifying the name of the environment to use.
 
-  # without pflib/.denv
+  # without pflib/.denv or pflib/.conda
   just -n configure
   cmake -B build -S .
+
+  # with pflib/.conda
+  just -n configure
+  conda run --name `cat .conda` -- cmake -B build -S .
 
   # with pflib/.denv
   just -n configure
   denv cmake -B build -S .
 
-Use 'just init <host>' to start using denv if desired.
+Use 'just init <host>' to start using denv if desired
+and 'just use-conda [name]' to use a conda environment
+if desired.
 
 RECIPES:
 "
@@ -20,7 +27,14 @@ _default:
     @just --list --unsorted --justfile {{justfile()}} --list-heading "{{ help_message }}"
 
 denv_exists := path_exists(justfile_directory() / ".denv")
-env_cmd_prefix := if denv_exists == "true" { "denv " } else { "" }
+conda_env_name := `cat .conda 2> /dev/null || echo "MISSING"`
+env_cmd_prefix := if path_exists(justfile_directory() / ".conda") == "true" {
+  f"conda run --name {{conda_env_name}} -- "
+  } else if denv_exists == "true" {
+    "denv "
+  } else {
+    ""
+  }
 
 _cmake *CONFIG:
     {{env_cmd_prefix}}cmake -B build -S . {{ CONFIG }}
@@ -38,6 +52,10 @@ init host:
     echo 'export PATH=${PATH}:${HOME}/install/bin' >> .profile
     echo 'export PYTHONPATH=${PYTHONPATH}:${HOME}/install/lib' >> .profile
     echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/install/lib' >> .profile
+
+# tell us which conda environment to use
+use-conda name="ldmx-env-base":
+    echo {{name}} > .conda
 
 # configure pflib build
 configure: _cmake

--- a/justfile
+++ b/justfile
@@ -24,38 +24,32 @@ RECIPES:
 "
 
 _default:
-    @just --list --unsorted --justfile {{justfile()}} --list-heading "{{ help_message }}"
+    @just --list --unsorted --justfile {{ justfile() }} --list-heading "{{ help_message }}"
 
 denv_exists := path_exists(justfile_directory() / ".denv")
 conda_env_name := `cat .conda 2> /dev/null || echo "MISSING"`
-env_cmd_prefix := if path_exists(justfile_directory() / ".conda") == "true" {
-  f"conda run --name {{conda_env_name}} -- "
-  } else if denv_exists == "true" {
-    "denv "
-  } else {
-    ""
-  }
+env_cmd_prefix := if path_exists(justfile_directory() / ".conda") == "true" { f"conda run --name {{conda_env_name}} -- " } else if denv_exists == "true" { "denv " } else { "" }
 
 _cmake *CONFIG:
-    {{env_cmd_prefix}}cmake -B build -S . {{ CONFIG }}
+    {{ env_cmd_prefix }}cmake -B build -S . {{ CONFIG }}
 
 _build *ARGS:
-    {{env_cmd_prefix}}cmake --build build -- {{ ARGS }}
+    {{ env_cmd_prefix }}cmake --build build -- {{ ARGS }}
 
 _test *ARGS:
-    cd build && {{env_cmd_prefix}}./test-pflib {{ ARGS }}
+    cd build && {{ env_cmd_prefix }}./test-pflib {{ ARGS }}
 
 # init a local denv for development ("zcu" or "bittware-host")
 init host:
     rm -f .profile
-    denv init ghcr.io/ldmx-software/pflib-env:{{host}}-latest
+    denv init ghcr.io/ldmx-software/pflib-env:{{ host }}-latest
     echo 'export PATH=${PATH}:${HOME}/install/bin' >> .profile
     echo 'export PYTHONPATH=${PYTHONPATH}:${HOME}/install/lib' >> .profile
     echo 'export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/install/lib' >> .profile
 
 # tell us which conda environment to use
 use-conda name="ldmx-env-base":
-    echo {{name}} > .conda
+    echo {{ name }} > .conda
 
 # configure pflib build
 configure: _cmake
@@ -65,20 +59,19 @@ build: _build
 
 # redirect build to log and open if build failed
 build-log:
-  #!/bin/bash
-  set -o nounset
-  set -o errexit
-  just build |& tee build.log
-  if ! [ ${PIPESTATUS[0]} -eq 0 ]; then
-    less -R build.log
-  fi
-
+    #!/bin/bash
+    set -o nounset
+    set -o errexit
+    just build |& tee build.log
+    if ! [ ${PIPESTATUS[0]} -eq 0 ]; then
+      less -R build.log
+    fi
 
 default_install_dir := justfile_directory() / "install"
 
 # install pflib to passed location
-install dir=default_install_dir: (_cmake "-DCMAKE_INSTALL_PREFIX="+dir)
-    {{env_cmd_prefix}}cmake --build build --target install
+install dir=default_install_dir: (_cmake "-DCMAKE_INSTALL_PREFIX=" + dir)
+    {{ env_cmd_prefix }}cmake --build build --target install
 
 # alias for configure and then build
 compile: configure build
@@ -104,27 +97,27 @@ clean:
 [no-cd]
 hexdump *args:
     hexdump -v -e '1/4 "%08x" "\n"' {{ args }}
-   
+
 # run the decoder
 pfdecoder *args:
-    {{env_cmd_prefix}}./build/pfdecoder {{ args }}
+    {{ env_cmd_prefix }}./build/pfdecoder {{ args }}
 
 # run the econd-decoder
 econd-decoder *args:
-    {{env_cmd_prefix}}./build/econd-decoder {{ args }}
+    {{ env_cmd_prefix }}./build/econd-decoder {{ args }}
 
 # open the test menu
 test-menu:
-    cd build && {{env_cmd_prefix}}make test-menu
-    {{env_cmd_prefix}}./build/test-menu
+    cd build && {{ env_cmd_prefix }}make test-menu
+    {{ env_cmd_prefix }}./build/test-menu
 
 # test decoding in python bindings
 test-py-decoding:
-    {{env_cmd_prefix}}PYTHONPATH=${PWD}/build LD_LIBRARY_PATH=${PWD}/build python3 test/decoding.py
+    {{ env_cmd_prefix }}PYTHONPATH=${PWD}/build LD_LIBRARY_PATH=${PWD}/build python3 test/decoding.py
 
 # py-rogue decoder from source
 rogue-decoder *args:
-    {{env_cmd_prefix}}./app/rogue-decoder.py {{args}}
+    {{ env_cmd_prefix }}./app/rogue-decoder.py {{ args }}
 
 # build the conda package on the DAQ server
 conda-package:


### PR DESCRIPTION
In some set ups, we use `conda` to supply the dependencies (mainly Rogue) and so supporting those within the `justfile` structure could be helpful.

Additionally, in these set ups, CMake tends to be really new and so we need to update the cmake policy to avoid annoying warnings at configuration time.