### PR TITLE
Econt decoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,9 @@ target_link_libraries(pfdecoder PRIVATE pflib)
 add_executable(econd-decoder app/econd_decoder.cxx)
 target_link_libraries(econd-decoder PRIVATE pflib)
 
+add_executable(econt-decoder app/econt_decoder.cxx)
+target_link_libraries(econt-decoder PRIVATE pflib)
+
 if (${Rogue_FOUND})
   add_executable(rogue-decoder app/rogue_decoder.cxx)
   target_link_libraries(rogue-decoder PUBLIC pflib Rogue::Rogue)

--- a/app/econt_decoder.cxx
+++ b/app/econt_decoder.cxx
@@ -1,10 +1,10 @@
-#include <iostream>
-#include <bitset>
 #include <array>
-#include <vector>
-#include <stdexcept>
-#include <sstream>
+#include <bitset>
 #include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
 
 uint32_t get_bits(const std::array<uint32_t, 3>& packet, int loc, int num) {
   if ((loc < 0) || (num < 1) || (num > 31) || (loc + num > 96)) {
@@ -13,49 +13,52 @@ uint32_t get_bits(const std::array<uint32_t, 3>& packet, int loc, int num) {
   int word = loc / 32;
   if (word != ((loc + num - 1) / 32)) {
     int split = 32 - (loc % 32);
-    return (((packet[word] >> (32 - ((loc + split) % 32))) & ((1u << split) - 1u)) << (num - split))
-            | ((packet[word + 1] >> (32 - (num - split))) & ((1u << (num - split)) - 1u));
+    return (((packet[word] >> (32 - ((loc + split) % 32))) &
+             ((1u << split) - 1u))
+            << (num - split)) |
+           ((packet[word + 1] >> (32 - (num - split))) &
+            ((1u << (num - split)) - 1u));
   }
   return (packet[word] >> (32 - ((loc + num) % 32))) & ((1u << num) - 1u);
 }
 
 uint64_t decode(uint32_t word) {
-  //we are using midpoint decoding, hence we set the bit after the mantissa to 1.
+  // we are using midpoint decoding, hence we set the bit after the mantissa
+  // to 1.
   uint64_t exponent = (word >> 4) & ((1u << 5) - 1u);
   uint64_t mantissa = word & ((1u << 4) - 1u);
   uint64_t l1 = exponent + 3;
   uint64_t output = 0;
   if (exponent > 0) {
-    output |= (1ull << l1) | (mantissa << (l1-4));
+    output |= (1ull << l1) | (mantissa << (l1 - 4));
     if (l1 >= 5) {
-      output |= (1ull << (l1 - 5)); // midpoint
+      output |= (1ull << (l1 - 5));  // midpoint
     }
-  }
-  else {
+  } else {
     output = mantissa;
   }
   return output;
 }
 
-
 int main(int argc, char* argv[]) {
   if (argc != 4) {
-      std::cout << "\nUsage: ./econt-decoder ./file.csv num_lines decode\n";
-      std::cout << "num_lines is the number of lines you would like to examine\n";
-      std::cout << "decode is 1 to view decoded data and 0 to view raw binary data\n\n";
-      return 1;
+    std::cout << "\nUsage: ./econt-decoder ./file.csv num_lines decode\n";
+    std::cout << "num_lines is the number of lines you would like to examine\n";
+    std::cout
+        << "decode is 1 to view decoded data and 0 to view raw binary data\n\n";
+    return 1;
   }
 
   std::ifstream file(argv[1]);
   if (!file) {
-      std::cerr << "Cannot open file\n";
-      return 1;
+    std::cerr << "Cannot open file\n";
+    return 1;
   }
   int max_lines = std::stoi(argv[2]);
   int decoded = std::stoi(argv[3]);
 
   std::string line;
-  std::getline(file, line); //skip the header
+  std::getline(file, line);  // skip the header
   int line_count = 0;
   while (std::getline(file, line) && (line_count < max_lines)) {
     std::stringstream ss(line);
@@ -64,7 +67,7 @@ int main(int argc, char* argv[]) {
     std::cout << "Decoding line " << line_count + 1 << "\n";
 
     while (std::getline(ss, value, ',')) {
-        row.push_back(value);
+      row.push_back(value);
     }
     if (row.size() < 3) {
       std::cout << "Incorrect CSV line length\n";
@@ -79,33 +82,35 @@ int main(int argc, char* argv[]) {
       packet[i] = std::stoul(row[i], nullptr, 16);
     }
 
-    //print the header
+    // print the header
     for (size_t i{0}; i < packet.size(); i++) {
       std::cout << "link" << i << ": " << std::bitset<32>(packet[i]) << "\n";
     }
     std::cout << "Header: " << std::bitset<4>(get_bits(packet, 0, 4)) << "\n";
 
-    //print max
+    // print max
     if (decoded == 0) {
       for (int i{0}; i < 8; i++) {
-        std::cout << "Max" << i+1 << ": " << std::bitset<2>(get_bits(packet,4+i*2,2)) << "\n";
+        std::cout << "Max" << i + 1 << ": "
+                  << std::bitset<2>(get_bits(packet, 4 + i * 2, 2)) << "\n";
       }
-    }
-    else {
+    } else {
       for (int i{0}; i < 8; i++) {
-        std::cout << "Max" << i+1 << ": " << get_bits(packet,4+i*2,2) << "\n";
+        std::cout << "Max" << i + 1 << ": " << get_bits(packet, 4 + i * 2, 2)
+                  << "\n";
       }
     }
 
-    //print STC
+    // print STC
     if (decoded == 0) {
       for (int i{0}; i < 8; i++) {
-        std::cout << "STC" << i+1 << ": " << std::bitset<9>(get_bits(packet,20+i*9,9)) << "\n";
+        std::cout << "STC" << i + 1 << ": "
+                  << std::bitset<9>(get_bits(packet, 20 + i * 9, 9)) << "\n";
       }
-    }
-    else {
+    } else {
       for (int i{0}; i < 8; i++) {
-        std::cout << "STC" << i+1 << ": " << decode(get_bits(packet,20+i*9,9)) << "\n";
+        std::cout << "STC" << i + 1 << ": "
+                  << decode(get_bits(packet, 20 + i * 9, 9)) << "\n";
       }
     }
     std::cout << "\n";

--- a/app/econt_decoder.cxx
+++ b/app/econt_decoder.cxx
@@ -1,0 +1,116 @@
+#include <iostream>
+#include <bitset>
+#include <array>
+#include <vector>
+#include <stdexcept>
+#include <sstream>
+#include <fstream>
+
+uint32_t get_bits(const std::array<uint32_t, 3>& packet, int loc, int num) {
+  if ((loc < 0) || (num < 1) || (num > 31) || (loc + num > 96)) {
+    throw std::invalid_argument("get_bits index out of bounds");
+  }
+  int word = loc / 32;
+  if (word != ((loc + num - 1) / 32)) {
+    int split = 32 - (loc % 32);
+    return (((packet[word] >> (32 - ((loc + split) % 32))) & ((1u << split) - 1u)) << (num - split))
+            | ((packet[word + 1] >> (32 - (num - split))) & ((1u << (num - split)) - 1u));
+  }
+  return (packet[word] >> (32 - ((loc + num) % 32))) & ((1u << num) - 1u);
+}
+
+uint64_t decode(uint32_t word) {
+  //we are using midpoint decoding, hence we set the bit after the mantissa to 1.
+  uint64_t exponent = (word >> 4) & ((1u << 5) - 1u);
+  uint64_t mantissa = word & ((1u << 4) - 1u);
+  uint64_t l1 = exponent + 3;
+  uint64_t output = 0;
+  if (exponent > 0) {
+    output |= (1ull << l1) | (mantissa << (l1-4));
+    if (l1 >= 5) {
+      output |= (1ull << (l1 - 5)); // midpoint
+    }
+  }
+  else {
+    output = mantissa;
+  }
+  return output;
+}
+
+
+int main(int argc, char* argv[]) {
+  if (argc != 4) {
+      std::cout << "\nUsage: ./econt-decoder ./file.csv num_lines decode\n";
+      std::cout << "num_lines is the number of lines you would like to examine\n";
+      std::cout << "decode is 1 to view decoded data and 0 to view raw binary data\n\n";
+      return 1;
+  }
+
+  std::ifstream file(argv[1]);
+  if (!file) {
+      std::cerr << "Cannot open file\n";
+      return 1;
+  }
+  int max_lines = std::stoi(argv[2]);
+  int decoded = std::stoi(argv[3]);
+
+  std::string line;
+  std::getline(file, line); //skip the header
+  int line_count = 0;
+  while (std::getline(file, line) && (line_count < max_lines)) {
+    std::stringstream ss(line);
+    std::string value;
+    std::vector<std::string> row;
+    std::cout << "Decoding line " << line_count + 1 << "\n";
+
+    while (std::getline(ss, value, ',')) {
+        row.push_back(value);
+    }
+    if (row.size() < 3) {
+      std::cout << "Incorrect CSV line length\n";
+      return 1;
+    }
+    std::array<uint32_t, 3> packet;
+    for (int i = 0; i < 3; i++) {
+      if (std::string(row[i]).size() != 8) {
+        std::cout << "Please provide a packet of the correct size\n";
+        return 1;
+      }
+      packet[i] = std::stoul(row[i], nullptr, 16);
+    }
+
+    //print the header
+    for (size_t i{0}; i < packet.size(); i++) {
+      std::cout << "link" << i << ": " << std::bitset<32>(packet[i]) << "\n";
+    }
+    std::cout << "Header: " << std::bitset<4>(get_bits(packet, 0, 4)) << "\n";
+
+    //print max
+    if (decoded == 0) {
+      for (int i{0}; i < 8; i++) {
+        std::cout << "Max" << i+1 << ": " << std::bitset<2>(get_bits(packet,4+i*2,2)) << "\n";
+      }
+    }
+    else {
+      for (int i{0}; i < 8; i++) {
+        std::cout << "Max" << i+1 << ": " << get_bits(packet,4+i*2,2) << "\n";
+      }
+    }
+
+    //print STC
+    if (decoded == 0) {
+      for (int i{0}; i < 8; i++) {
+        std::cout << "STC" << i+1 << ": " << std::bitset<9>(get_bits(packet,20+i*9,9)) << "\n";
+      }
+    }
+    else {
+      for (int i{0}; i < 8; i++) {
+        std::cout << "STC" << i+1 << ": " << decode(get_bits(packet,20+i*9,9)) << "\n";
+      }
+    }
+    std::cout << "\n";
+    line_count += 1;
+  }
+  file.close();
+  return 0;
+}

--- a/include/pflib/Exception.h
+++ b/include/pflib/Exception.h
@@ -26,8 +26,8 @@ class Exception : public std::exception {
    * @param line Line in the source code where the exception occurred.
    * @param function Function in which the exception occurred.
    */
-  Exception(const std::string &name, const std::string &message,
-            const std::string &module, int line, const std::string &function)
+  Exception(const std::string& name, const std::string& message,
+            const std::string& module, int line, const std::string& function)
       : name_{name},
         message_{message},
         module_{module},
@@ -43,25 +43,25 @@ class Exception : public std::exception {
    * Get the name of the exception.
    * @return The name of the exception.
    */
-  const std::string &name() const throw() { return name_; }
+  const std::string& name() const throw() { return name_; }
 
   /**
    * Get the message of the exception.
    * @return The message of the exception.
    */
-  const std::string &message() const throw() { return message_; }
+  const std::string& message() const throw() { return message_; }
 
   /**
    * Get the source filename where the exception occurred.
    * @return The source filename where the exception occurred.
    */
-  const std::string &module() const throw() { return module_; }
+  const std::string& module() const throw() { return module_; }
 
   /**
    * Get the function name where the exception occurred.
    * @return The function name where the exception occurred.
    */
-  const std::string &function() const throw() { return function_; }
+  const std::string& function() const throw() { return function_; }
 
   /**
    * Get the source line number where the exception occurred.
@@ -73,7 +73,7 @@ class Exception : public std::exception {
    * The error message.
    * @return The error message.
    */
-  virtual const char *what() const throw() { return message_.c_str(); }
+  virtual const char* what() const throw() { return message_.c_str(); }
 
  private:
   /** Exception name. */

--- a/src/pflib/packing/ECONDEventPacket.cxx
+++ b/src/pflib/packing/ECONDEventPacket.cxx
@@ -11,7 +11,7 @@
 namespace pflib::packing {
 
 std::size_t ECONDEventPacket::unpack_link_subpacket(std::span<uint32_t> data,
-                                                    DAQLinkFrame &link,
+                                                    DAQLinkFrame& link,
                                                     bool passthrough) {
   pflib_log(trace) << "link header " << hex(data[0]);
   // sub-packet start
@@ -56,7 +56,7 @@ std::size_t ECONDEventPacket::unpack_link_subpacket(std::span<uint32_t> data,
                      << " i_ch=" << i_chan;
 
     // deduce a reference to the channel that we are unpacking
-    Sample *ch = &(link.calib);
+    Sample* ch = &(link.calib);
     if (i_chan < 18) {
       ch = &(link.channels[i_chan]);
     } else if (i_chan > 18) {
@@ -327,7 +327,7 @@ void ECONDEventPacket::from(std::span<uint32_t> data) {
   }
 
   std::size_t offset{2};
-  for (auto &link : links) {
+  for (auto& link : links) {
     offset += unpack_link_subpacket(data.subspan(offset), link, passthrough);
     link.bx = bx;
     link.event = l1a;


### PR DESCRIPTION
- Creates a program which can decode ST4 econt data in .csv format

Example input:
[testOutput.csv](https://github.com/user-attachments/files/30098447/testOutput.csv)

How to use:
```
cd pflib/build
./econt-decoder ./testOutput.csv num_lines decode
```
- num_lines is the number of lines you would like to examine
- decode is 1 to view decoded data and 0 to view raw binary data

For example, type
```
./econt-decoder ./testOutput.csv 3 1
```
to see 3 lines of decoded econt data.
