### PR TITLE
Iss407 pedestal refactor

### DIFF
--- a/app/tool/algorithm/local_pedestal_level.cxx
+++ b/app/tool/algorithm/local_pedestal_level.cxx
@@ -74,9 +74,9 @@ local_pedestal_level(Target* tgt) {
   // each channel has measurements at different parameter points
   std::map<int, std::array<int, 72>> baseline, highend, lowend;
   // will fill with standard deviations so we can ommit dead channels
-  std::map<int, std::array<int, 72>> basedevs, highdevs, lowdevs;
+  std::map<int, std::array<int, 72>> basedevs;
   // include all zero parmeter run values since hcal used DACB and SIGN_DAC
-  std::map<int, std::array<int, 72>> allzero, zerodevs;
+  std::map<int, std::array<int, 72>> allzero;
 
   DecodeAndBuffer buffer{n_events, tgt->nrocs() * 2};
 
@@ -94,9 +94,7 @@ local_pedestal_level(Target* tgt) {
 	    parameters[ch_str]["TRIM_INV"] = 32; 
 	  }
     }
-    std::cout << "im alive" << std::endl;
     auto test_params = tgt->tempApplyAllROCs(parameters);
-    std::cout << "im still alive" << std::endl;
 
     daq_run(tgt, "PEDESTAL", buffer, n_events, 100);
     pflib_log(trace) << "baseline run done, getting channel medians";
@@ -124,30 +122,22 @@ local_pedestal_level(Target* tgt) {
   }
 
   if ( pftool::state.readout_config_is_hcal() ) {
-    {  // allzero run scope (SIGN_DAC = DACB = TRIM_INV = 0)
-      pflib_log(info) << "100 event all-zero-parameters run";
-      std::map<std::string, std::map<std::string, uint64_t>> parameters;
-      for (int ch{0}; ch < 72; ch++) {
-        std::string ch_str{"CH_" + std::to_string(ch)};
-	   // if ( pftool::state.readout_config_is_hcal() ) {
-        parameters[ch_str]["SIGN_DAC"] = 0;
-        parameters[ch_str]["DACB"] = 0;
-        parameters[ch_str]["TRIM_INV"] = 0;
-	   // }
-	   // else {
-	     // parameters[ch_str]["TRIM_INV"] = 0; 
-	   // }
-      }
-      auto test_params = tgt->tempApplyAllROCs(parameters);
+    // allzero run scope (SIGN_DAC = DACB = TRIM_INV = 0)
+    pflib_log(info) << "100 event all-zero-parameters run";
+    std::map<std::string, std::map<std::string, uint64_t>> parameters;
+    for (int ch{0}; ch < 72; ch++) {
+      std::string ch_str{"CH_" + std::to_string(ch)};
+      parameters[ch_str]["SIGN_DAC"] = 0;
+      parameters[ch_str]["DACB"] = 0;
+      parameters[ch_str]["TRIM_INV"] = 0;
+    }
+    auto test_params = tgt->tempApplyAllROCs(parameters);
 
-      daq_run(tgt, "PEDESTAL", buffer, n_events, 100);
-      pflib_log(trace) << "all-zero-params run done, getting channel medians";
-      for (int i_roc : tgt->roc_ids()) {
-        allzero[i_roc] =
-            get_adc_medians(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
-	    zerodevs[i_roc] =
-            get_adc_stdevs(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
-      }
+    daq_run(tgt, "PEDESTAL", buffer, n_events, 100);
+    pflib_log(trace) << "all-zero-params run done, getting channel medians";
+    for (int i_roc : tgt->roc_ids()) {
+      allzero[i_roc] =
+          get_adc_medians(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
     }
   }
 
@@ -172,8 +162,6 @@ local_pedestal_level(Target* tgt) {
     for (int i_roc : tgt->roc_ids()) {
       highend[i_roc] =
           get_adc_medians(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
-	  highdevs[i_roc] =
-          get_adc_stdevs(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
     }
   }
 
@@ -198,8 +186,6 @@ local_pedestal_level(Target* tgt) {
     for (int i_roc : tgt->roc_ids()) {
       lowend[i_roc] =
           get_adc_medians(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
-	  lowdevs[i_roc] =
-          get_adc_stdevs(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
     }
   }
 
@@ -208,6 +194,9 @@ local_pedestal_level(Target* tgt) {
       settings;
   for (int i_roc : tgt->roc_ids()) {
     for (int ch{0}; ch < 72; ch++) {
+      if (basedevs[i_roc].at(ch) == 0) {
+        continue;      
+      }
       std::string page{pflib::utility::string_format("CH_%d", ch)};
       int i_half = ch / 36;
       if (baseline[i_roc].at(ch) < target[i_roc].at(i_half)) {

--- a/app/tool/algorithm/local_pedestal_level.cxx
+++ b/app/tool/algorithm/local_pedestal_level.cxx
@@ -1,12 +1,12 @@
 #include "local_pedestal_level.h"
 
+#include <iostream>
+
 #include "../daq_run.h"
 #include "../tasks/local_pedestal_level.h"
 #include "pflib/utility/median.h"
 #include "pflib/utility/stdev.h"
 #include "pflib/utility/string_format.h"
-
-#include <iostream>
 
 namespace pflib::algorithm {
 
@@ -85,31 +85,30 @@ local_pedestal_level(Target* tgt) {
     std::map<std::string, std::map<std::string, uint64_t>> parameters;
     for (int ch{0}; ch < 72; ch++) {
       std::string ch_str{"CH_" + std::to_string(ch)};
-	  if ( pftool::state.readout_config_is_hcal() ) {
+      if (pftool::state.readout_config_is_hcal()) {
         parameters[ch_str]["SIGN_DAC"] = 0;
         parameters[ch_str]["DACB"] = 0;
         parameters[ch_str]["TRIM_INV"] = 32;
-	  }
-	  else {
-	    parameters[ch_str]["TRIM_INV"] = 32; 
-	  }
+      } else {
+        parameters[ch_str]["TRIM_INV"] = 32;
+      }
     }
     auto test_params = tgt->tempApplyAllROCs(parameters);
 
     daq_run(tgt, "PEDESTAL", buffer, n_events, 100);
     pflib_log(trace) << "baseline run done, getting channel medians";
     std::map<int, std::array<int, 72>> medians;
-	std::map<int, std::array<double, 72>> stdevs;
+    std::map<int, std::array<double, 72>> stdevs;
     for (int i_roc : tgt->roc_ids()) {
       medians[i_roc] =
           get_adc_medians(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
-	  basedevs[i_roc] =
+      basedevs[i_roc] =
           get_adc_stdevs(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
       for (const auto& num : basedevs[i_roc]) {
         pflib_log(debug) << num << " ";
       }
     }
-    baseline = medians; 
+    baseline = medians;
     pflib_log(trace) << "got channel medians, getting link medians";
     for (int i_half{0}; i_half < 2; i_half++) {
       for (int i_roc : tgt->roc_ids()) {
@@ -123,7 +122,7 @@ local_pedestal_level(Target* tgt) {
     pflib_log(trace) << "got medians per half";
   }
 
-  if ( pftool::state.readout_config_is_hcal() ) {
+  if (pftool::state.readout_config_is_hcal()) {
     // allzero run scope (SIGN_DAC = DACB = TRIM_INV = 0)
     pflib_log(info) << "100 event all-zero-parameters run";
     std::map<std::string, std::map<std::string, uint64_t>> parameters;
@@ -148,14 +147,13 @@ local_pedestal_level(Target* tgt) {
     std::map<std::string, std::map<std::string, uint64_t>> parameters;
     for (int ch{0}; ch < 72; ch++) {
       std::string ch_str{"CH_" + std::to_string(ch)};
-	  if ( pftool::state.readout_config_is_hcal() ) {
+      if (pftool::state.readout_config_is_hcal()) {
         parameters[ch_str]["SIGN_DAC"] = 0;
         parameters[ch_str]["DACB"] = 0;
         parameters[ch_str]["TRIM_INV"] = 63;
-	  }
-	  else {
+      } else {
         parameters[ch_str]["TRIM_INV"] = 63;
-	  }
+      }
     }
     auto test_params = tgt->tempApplyAllROCs(parameters);
 
@@ -172,14 +170,13 @@ local_pedestal_level(Target* tgt) {
     std::map<std::string, std::map<std::string, uint64_t>> parameters;
     for (int ch{0}; ch < 72; ch++) {
       std::string ch_str{"CH_" + std::to_string(ch)};
-	  if ( pftool::state.readout_config_is_hcal() ) {
+      if (pftool::state.readout_config_is_hcal()) {
         parameters[ch_str]["SIGN_DAC"] = 1;
         parameters[ch_str]["DACB"] = 31;
         parameters[ch_str]["TRIM_INV"] = 0;
-	  }
-	  else {
+      } else {
         parameters[ch_str]["TRIM_INV"] = 0;
-	  }
+      }
     }
     auto test_params = tgt->tempApplyAllROCs(parameters);
 
@@ -197,7 +194,7 @@ local_pedestal_level(Target* tgt) {
   for (int i_roc : tgt->roc_ids()) {
     for (int ch{0}; ch < 72; ch++) {
       if (basedevs[i_roc].at(ch) == 0) {
-        continue;      
+        continue;
       }
       std::string page{pflib::utility::string_format("CH_%d", ch)};
       int i_half = ch / 36;
@@ -221,123 +218,126 @@ local_pedestal_level(Target* tgt) {
           settings[i_roc][page]["TRIM_INV"] = 63;
           continue;
         }
-		// scale is in [0,1]
-        double optim = 32 + ( scale * 31 );
+        // scale is in [0,1]
+        double optim = 32 + (scale * 31);
         uint64_t val = static_cast<uint64_t>(optim);
         pflib_log(trace) << "Scale " << scale << " giving optimal value of "
                          << optim << " which rounds to " << val;
         settings[i_roc][page]["TRIM_INV"] = val;
-		continue;
-      } else /* baseline[ch] > target[i_half]  */{
+        continue;
+      } else /* baseline[ch] > target[i_half]  */ {
         double scale = static_cast<double>(baseline[i_roc].at(ch) -
                                            target[i_roc].at(i_half)) /
                        (baseline[i_roc].at(ch) - lowend[i_roc].at(ch));
-        if ( scale < 0 && pftool::state.readout_config_is_hcal() ) {
+        if (scale < 0 && pftool::state.readout_config_is_hcal()) {
           pflib_log(warn) << "Channel " << ch
                           << " is above target but decreasing TRIM_INV "
-							 "and using SIGN_DAC=1 and increasing DACB "
+                             "and using SIGN_DAC=1 and increasing DACB "
                              "made it higher??? Skipping...";
           continue;
         }
-		if ( scale < 0 && !pftool::state.readout_config_is_hcal() ) {
+        if (scale < 0 && !pftool::state.readout_config_is_hcal()) {
           pflib_log(warn) << "Channel " << ch
                           << " is above target but decreasing TRIM_INV "
                              "made it higher??? Skipping...";
           continue;
         }
-		if (scale > 1 && pftool::state.readout_config_is_hcal() ) {
+        if (scale > 1 && pftool::state.readout_config_is_hcal()) {
           pflib_log(warn)
-            << "Channel " << ch
-            << " is so far above target that we cannot lower it enough."
-            << " Setting SIGN_DAC=1 and DACB to its maximumum."
-		    << " Setting TRIM_INV = 0.";
-		  settings[i_roc][page]["TRIM_INV"] = 0;
+              << "Channel " << ch
+              << " is so far above target that we cannot lower it enough."
+              << " Setting SIGN_DAC=1 and DACB to its maximumum."
+              << " Setting TRIM_INV = 0.";
+          settings[i_roc][page]["TRIM_INV"] = 0;
           settings[i_roc][page]["SIGN_DAC"] = 1;
           settings[i_roc][page]["DACB"] = 31;
           continue;
         }
-        if (scale > 1 && !pftool::state.readout_config_is_hcal() ) {
+        if (scale > 1 && !pftool::state.readout_config_is_hcal()) {
           pflib_log(warn)
-            << "Channel " << ch
-            << " is so far above target that we cannot lower it enough."
-		    << " Setting TRIM_INV = 0.";
-		  settings[i_roc][page]["TRIM_INV"] = 0;
+              << "Channel " << ch
+              << " is so far above target that we cannot lower it enough."
+              << " Setting TRIM_INV = 0.";
+          settings[i_roc][page]["TRIM_INV"] = 0;
           continue;
         }
-		// scale is in [0,1]
-		double diff = static_cast<double>(baseline[i_roc].at(ch) -
-                                         target[i_roc].at(i_half));
-		if ( pftool::state.readout_config_is_hcal() ) {
-		  double trim_diff = static_cast<double>(baseline[i_roc].at(ch) -
-                                                allzero[i_roc].at(ch));
-		  double dacb_diff = static_cast<double>(allzero[i_roc].at(ch) -
-                                                lowend[i_roc].at(ch));
-		  if (trim_diff < 0 || dacb_diff < 0) {
-		    pflib_log(debug) << "Channel " << ch
-							 << " is above target but lowering TRIM_INV "
-							 << "or setting SIGN_DAC = 1 and raising DACB"
-							 << " made it higher??? Skipping...";
-			continue;
-		  }
-		  if (diff <= trim_diff) {
-		    double optim = 32 - ( (diff / trim_diff) * 32 );
-			uint64_t val = static_cast<uint64_t>(optim);
-            pflib_log(trace) << "Scale " << (diff/trim_diff)
-							 << " giving optimal value of "
-                             << optim << " for TRIM_INV" 
-							    " which rounds to " << val;
-		    if (val ==0 ) {
-              pflib_log(debug) << "Channel " << ch
-                               << " is above target but too close to use TRIM_INV "
-                                  "to lower, skipping.";
-			} else {
-			  pflib_log(debug) << "Channel " << ch
-                               << " is above target, lowering TRIM_INV";
-			  settings[i_roc][page]["TRIM_INV"] = val;
-			}
-	      }
-		  else /* diff > trim_diff */ {
-            double optim = ( (diff - trim_diff) / dacb_diff ) * 31;
-			uint64_t val = static_cast<uint64_t>(optim);
-            pflib_log(trace) << "Scale " << ((diff-trim_diff)/dacb_diff)
-							 << " giving optimal value of "
-                             << optim << " for DACB"
-							    " which rounds to " << val;
-			if (val == 0) {
-			  pflib_log(debug) << "Channel " << ch
-							   << " is above target but too close to use DACB "
-								  "to lower. Setting TRIM_INV = 0";
-			  settings[i_roc][page]["TRIM_INV"] = 0;
-			} else {
-			  pflib_log(debug) << "Channel" << ch
-							   << " is above target, setting TRIM_INV = 0."
-								  " Setting SIGN_DAC = 1 and DACB.";
-			  settings[i_roc][page]["TRIM_INV"] = 0;
-			  settings[i_roc][page]["SIGN_DAC"] = 1;
-			  settings[i_roc][page]["DACB"] = val;
+        // scale is in [0,1]
+        double diff = static_cast<double>(baseline[i_roc].at(ch) -
+                                          target[i_roc].at(i_half));
+        if (pftool::state.readout_config_is_hcal()) {
+          double trim_diff = static_cast<double>(baseline[i_roc].at(ch) -
+                                                 allzero[i_roc].at(ch));
+          double dacb_diff =
+              static_cast<double>(allzero[i_roc].at(ch) - lowend[i_roc].at(ch));
+          if (trim_diff < 0 || dacb_diff < 0) {
+            pflib_log(debug)
+                << "Channel " << ch << " is above target but lowering TRIM_INV "
+                << "or setting SIGN_DAC = 1 and raising DACB"
+                << " made it higher??? Skipping...";
+            continue;
+          }
+          if (diff <= trim_diff) {
+            double optim = 32 - ((diff / trim_diff) * 32);
+            uint64_t val = static_cast<uint64_t>(optim);
+            pflib_log(trace) << "Scale " << (diff / trim_diff)
+                             << " giving optimal value of " << optim
+                             << " for TRIM_INV"
+                                " which rounds to "
+                             << val;
+            if (val == 0) {
+              pflib_log(debug)
+                  << "Channel " << ch
+                  << " is above target but too close to use TRIM_INV "
+                     "to lower, skipping.";
+            } else {
+              pflib_log(debug)
+                  << "Channel " << ch << " is above target, lowering TRIM_INV";
+              settings[i_roc][page]["TRIM_INV"] = val;
             }
-		  }
-        }
-		else /* ecal */ {
-		  double optim = 32 - ( scale * 32 );
-		  uint64_t val = static_cast<uint64_t>(optim);
-	      pflib_log(trace) << "Scale " << scale
-							 << " giving optimal value of "
-                             << optim << " for TRIM_INV"
-							    " which rounds to " << val;
-		  if (val == 0) {
-		    pflib_log(debug) << "Channel" << ch
-						     << " is above target but too close to use TRIM_INV "
-								"to lower, skipping.";
-		  } else {
-		    pflib_log(debug) << "Channel" << ch
-						     << " is above target, setting TRIM_INV.";
-		    settings[i_roc][page]["TRIM_INV"] = val;
-		  } 
-		} // end if ecal
-      } // end if baseline > target
-    } // end loop over channels
-  } // end loop over rocs
+          } else /* diff > trim_diff */ {
+            double optim = ((diff - trim_diff) / dacb_diff) * 31;
+            uint64_t val = static_cast<uint64_t>(optim);
+            pflib_log(trace) << "Scale " << ((diff - trim_diff) / dacb_diff)
+                             << " giving optimal value of " << optim
+                             << " for DACB"
+                                " which rounds to "
+                             << val;
+            if (val == 0) {
+              pflib_log(debug) << "Channel " << ch
+                               << " is above target but too close to use DACB "
+                                  "to lower. Setting TRIM_INV = 0";
+              settings[i_roc][page]["TRIM_INV"] = 0;
+            } else {
+              pflib_log(debug) << "Channel" << ch
+                               << " is above target, setting TRIM_INV = 0."
+                                  " Setting SIGN_DAC = 1 and DACB.";
+              settings[i_roc][page]["TRIM_INV"] = 0;
+              settings[i_roc][page]["SIGN_DAC"] = 1;
+              settings[i_roc][page]["DACB"] = val;
+            }
+          }
+        } else /* ecal */ {
+          double optim = 32 - (scale * 32);
+          uint64_t val = static_cast<uint64_t>(optim);
+          pflib_log(trace) << "Scale " << scale << " giving optimal value of "
+                           << optim
+                           << " for TRIM_INV"
+                              " which rounds to "
+                           << val;
+          if (val == 0) {
+            pflib_log(debug)
+                << "Channel" << ch
+                << " is above target but too close to use TRIM_INV "
+                   "to lower, skipping.";
+          } else {
+            pflib_log(debug)
+                << "Channel" << ch << " is above target, setting TRIM_INV.";
+            settings[i_roc][page]["TRIM_INV"] = val;
+          }
+        }  // end if ecal
+      }  // end if baseline > target
+    }  // end loop over channels
+  }  // end loop over rocs
 
   return settings;
 }

--- a/app/tool/algorithm/local_pedestal_level.cxx
+++ b/app/tool/algorithm/local_pedestal_level.cxx
@@ -41,10 +41,10 @@ static std::array<int, 72> get_adc_medians(
   return medians;
 }
 
-static std::array<int, 72> get_adc_stdevs(
+static std::array<double, 72> get_adc_stdevs(
     int i_roc, const pflib::packing::SingleECONDRocErxMapping& mapping,
     const std::vector<pflib::packing::MultiSampleECONDEventPacket>& data) {
-  std::array<int, 72> stdevs;
+  std::array<double, 72> stdevs;
   /// reserve a vector of the appropriate size to avoid repeating allocation
   /// time for all 72 channels
   std::vector<int> adcs(data.size());
@@ -74,7 +74,7 @@ local_pedestal_level(Target* tgt) {
   // each channel has measurements at different parameter points
   std::map<int, std::array<int, 72>> baseline, highend, lowend;
   // will fill with standard deviations so we can ommit dead channels
-  std::map<int, std::array<int, 72>> basedevs;
+  std::map<int, std::array<double, 72>> basedevs;
   // include all zero parmeter run values since hcal used DACB and SIGN_DAC
   std::map<int, std::array<int, 72>> allzero;
 
@@ -99,15 +99,17 @@ local_pedestal_level(Target* tgt) {
     daq_run(tgt, "PEDESTAL", buffer, n_events, 100);
     pflib_log(trace) << "baseline run done, getting channel medians";
     std::map<int, std::array<int, 72>> medians;
-	std::map<int, std::array<int, 72>> stdevs;
+	std::map<int, std::array<double, 72>> stdevs;
     for (int i_roc : tgt->roc_ids()) {
       medians[i_roc] =
           get_adc_medians(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
-	  stdevs[i_roc] =
+	  basedevs[i_roc] =
           get_adc_stdevs(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
+      for (const auto& num : basedevs[i_roc]) {
+        pflib_log(debug) << num << " ";
+      }
     }
-    baseline = medians;
-	basedevs = stdevs;
+    baseline = medians; 
     pflib_log(trace) << "got channel medians, getting link medians";
     for (int i_half{0}; i_half < 2; i_half++) {
       for (int i_roc : tgt->roc_ids()) {
@@ -317,11 +319,9 @@ local_pedestal_level(Target* tgt) {
 		  }
         }
 		else /* ecal */ {
-		  double trim_diff = static_cast<double>(baseline[i_roc].at(ch) -
-                                                lowend[i_roc].at(ch));
 		  double optim = 32 - ( scale * 32 );
 		  uint64_t val = static_cast<uint64_t>(optim);
-	      pflib_log(trace) << "Scale " << (diff/trim_diff)
+	      pflib_log(trace) << "Scale " << scale
 							 << " giving optimal value of "
                              << optim << " for TRIM_INV"
 							    " which rounds to " << val;

--- a/app/tool/algorithm/local_pedestal_level.cxx
+++ b/app/tool/algorithm/local_pedestal_level.cxx
@@ -3,7 +3,10 @@
 #include "../daq_run.h"
 #include "../tasks/local_pedestal_level.h"
 #include "pflib/utility/median.h"
+#include "pflib/utility/stdev.h"
 #include "pflib/utility/string_format.h"
+
+#include <iostream>
 
 namespace pflib::algorithm {
 
@@ -38,6 +41,23 @@ static std::array<int, 72> get_adc_medians(
   return medians;
 }
 
+static std::array<int, 72> get_adc_stdevs(
+    int i_roc, const pflib::packing::SingleECONDRocErxMapping& mapping,
+    const std::vector<pflib::packing::MultiSampleECONDEventPacket>& data) {
+  std::array<int, 72> stdevs;
+  /// reserve a vector of the appropriate size to avoid repeating allocation
+  /// time for all 72 channels
+  std::vector<int> adcs(data.size());
+  for (int ch{0}; ch < 72; ch++) {
+    for (std::size_t i{0}; i < adcs.size(); i++) {
+      auto [i_erx, i_ch] = mapping.toErxChannel(i_roc, ch);
+      adcs[i] = data[i].soi().channel(i_erx, i_ch).adc();
+    }
+    stdevs[ch] = pflib::utility::stdev(adcs);
+  }
+  return stdevs;
+}
+
 std::map<int, std::map<std::string, std::map<std::string, uint64_t>>>
 local_pedestal_level(Target* tgt) {
   static auto the_log_{::pflib::logging::get("local_pedestal_level")};
@@ -53,6 +73,10 @@ local_pedestal_level(Target* tgt) {
   std::map<int, std::array<int, 2>> target;
   // each channel has measurements at different parameter points
   std::map<int, std::array<int, 72>> baseline, highend, lowend;
+  // will fill with standard deviations so we can ommit dead channels
+  std::map<int, std::array<int, 72>> basedevs, highdevs, lowdevs;
+  // include all zero parmeter run values since hcal used DACB and SIGN_DAC
+  std::map<int, std::array<int, 72>> allzero, zerodevs;
 
   DecodeAndBuffer buffer{n_events, tgt->nrocs() * 2};
 
@@ -61,20 +85,31 @@ local_pedestal_level(Target* tgt) {
     std::map<std::string, std::map<std::string, uint64_t>> parameters;
     for (int ch{0}; ch < 72; ch++) {
       std::string ch_str{"CH_" + std::to_string(ch)};
-      parameters[ch_str]["SIGN_DAC"] = 0;
-      parameters[ch_str]["DACB"] = 0;
-      parameters[ch_str]["TRIM_INV"] = 0;
+	  if ( pftool::state.readout_config_is_hcal() ) {
+        parameters[ch_str]["SIGN_DAC"] = 0;
+        parameters[ch_str]["DACB"] = 0;
+        parameters[ch_str]["TRIM_INV"] = 32;
+	  }
+	  else {
+	    parameters[ch_str]["TRIM_INV"] = 32; 
+	  }
     }
+    std::cout << "im alive" << std::endl;
     auto test_params = tgt->tempApplyAllROCs(parameters);
+    std::cout << "im still alive" << std::endl;
 
     daq_run(tgt, "PEDESTAL", buffer, n_events, 100);
     pflib_log(trace) << "baseline run done, getting channel medians";
     std::map<int, std::array<int, 72>> medians;
+	std::map<int, std::array<int, 72>> stdevs;
     for (int i_roc : tgt->roc_ids()) {
       medians[i_roc] =
           get_adc_medians(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
+	  stdevs[i_roc] =
+          get_adc_stdevs(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
     }
     baseline = medians;
+	basedevs = stdevs;
     pflib_log(trace) << "got channel medians, getting link medians";
     for (int i_half{0}; i_half < 2; i_half++) {
       for (int i_roc : tgt->roc_ids()) {
@@ -88,14 +123,47 @@ local_pedestal_level(Target* tgt) {
     pflib_log(trace) << "got medians per half";
   }
 
+  if ( pftool::state.readout_config_is_hcal() ) {
+    {  // allzero run scope (SIGN_DAC = DACB = TRIM_INV = 0)
+      pflib_log(info) << "100 event all-zero-parameters run";
+      std::map<std::string, std::map<std::string, uint64_t>> parameters;
+      for (int ch{0}; ch < 72; ch++) {
+        std::string ch_str{"CH_" + std::to_string(ch)};
+	   // if ( pftool::state.readout_config_is_hcal() ) {
+        parameters[ch_str]["SIGN_DAC"] = 0;
+        parameters[ch_str]["DACB"] = 0;
+        parameters[ch_str]["TRIM_INV"] = 0;
+	   // }
+	   // else {
+	     // parameters[ch_str]["TRIM_INV"] = 0; 
+	   // }
+      }
+      auto test_params = tgt->tempApplyAllROCs(parameters);
+
+      daq_run(tgt, "PEDESTAL", buffer, n_events, 100);
+      pflib_log(trace) << "all-zero-params run done, getting channel medians";
+      for (int i_roc : tgt->roc_ids()) {
+        allzero[i_roc] =
+            get_adc_medians(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
+	    zerodevs[i_roc] =
+            get_adc_stdevs(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
+      }
+    }
+  }
+
   {  // highend run scope
     pflib_log(info) << "100 event highend run";
     std::map<std::string, std::map<std::string, uint64_t>> parameters;
     for (int ch{0}; ch < 72; ch++) {
       std::string ch_str{"CH_" + std::to_string(ch)};
-      parameters[ch_str]["SIGN_DAC"] = 0;
-      parameters[ch_str]["DACB"] = 0;
-      parameters[ch_str]["TRIM_INV"] = 63;
+	  if ( pftool::state.readout_config_is_hcal() ) {
+        parameters[ch_str]["SIGN_DAC"] = 0;
+        parameters[ch_str]["DACB"] = 0;
+        parameters[ch_str]["TRIM_INV"] = 63;
+	  }
+	  else {
+        parameters[ch_str]["TRIM_INV"] = 63;
+	  }
     }
     auto test_params = tgt->tempApplyAllROCs(parameters);
 
@@ -104,6 +172,8 @@ local_pedestal_level(Target* tgt) {
     for (int i_roc : tgt->roc_ids()) {
       highend[i_roc] =
           get_adc_medians(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
+	  highdevs[i_roc] =
+          get_adc_stdevs(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
     }
   }
 
@@ -112,9 +182,14 @@ local_pedestal_level(Target* tgt) {
     std::map<std::string, std::map<std::string, uint64_t>> parameters;
     for (int ch{0}; ch < 72; ch++) {
       std::string ch_str{"CH_" + std::to_string(ch)};
-      parameters[ch_str]["SIGN_DAC"] = 1;
-      parameters[ch_str]["DACB"] = 31;
-      parameters[ch_str]["TRIM_INV"] = 0;
+	  if ( pftool::state.readout_config_is_hcal() ) {
+        parameters[ch_str]["SIGN_DAC"] = 1;
+        parameters[ch_str]["DACB"] = 31;
+        parameters[ch_str]["TRIM_INV"] = 0;
+	  }
+	  else {
+        parameters[ch_str]["TRIM_INV"] = 0;
+	  }
     }
     auto test_params = tgt->tempApplyAllROCs(parameters);
 
@@ -123,6 +198,8 @@ local_pedestal_level(Target* tgt) {
     for (int i_roc : tgt->roc_ids()) {
       lowend[i_roc] =
           get_adc_medians(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
+	  lowdevs[i_roc] =
+          get_adc_stdevs(i_roc, tgt->getRocErxMapping(), buffer.get_buffer());
     }
   }
 
@@ -153,48 +230,125 @@ local_pedestal_level(Target* tgt) {
           settings[i_roc][page]["TRIM_INV"] = 63;
           continue;
         }
-        // scale is in [0,1]
-        double optim = scale * 63;
+		// scale is in [0,1]
+        double optim = 32 + ( scale * 31 );
         uint64_t val = static_cast<uint64_t>(optim);
         pflib_log(trace) << "Scale " << scale << " giving optimal value of "
                          << optim << " which rounds to " << val;
         settings[i_roc][page]["TRIM_INV"] = val;
-      } else {
+		continue;
+      } else /* baseline[ch] > target[i_half]  */{
         double scale = static_cast<double>(baseline[i_roc].at(ch) -
                                            target[i_roc].at(i_half)) /
                        (baseline[i_roc].at(ch) - lowend[i_roc].at(ch));
-        if (scale < 0) {
+        if ( scale < 0 && pftool::state.readout_config_is_hcal() ) {
           pflib_log(warn) << "Channel " << ch
-                          << " is above target but using SIGN_DAC=1 and "
-                             "increasing DACB made it higher??? Skipping...";
+                          << " is above target but decreasing TRIM_INV "
+							 "and using SIGN_DAC=1 and increasing DACB "
+                             "made it higher??? Skipping...";
           continue;
         }
-        if (scale > 1) {
+		if ( scale < 0 && !pftool::state.readout_config_is_hcal() ) {
+          pflib_log(warn) << "Channel " << ch
+                          << " is above target but decreasing TRIM_INV "
+                             "made it higher??? Skipping...";
+          continue;
+        }
+		if (scale > 1 && pftool::state.readout_config_is_hcal() ) {
           pflib_log(warn)
-              << "Channel " << ch
-              << " is so far above target that we cannot lower it enough."
-              << " Setting SIGN_DAC=1 and DACB to its maximum.";
+            << "Channel " << ch
+            << " is so far above target that we cannot lower it enough."
+            << " Setting SIGN_DAC=1 and DACB to its maximumum."
+		    << " Setting TRIM_INV = 0.";
+		  settings[i_roc][page]["TRIM_INV"] = 0;
           settings[i_roc][page]["SIGN_DAC"] = 1;
           settings[i_roc][page]["DACB"] = 31;
           continue;
         }
-        double optim = scale * 31;
-        uint64_t val = static_cast<uint64_t>(optim);
-        pflib_log(trace) << "Scale " << scale << " giving optimal value of "
-                         << optim << " which rounds to " << val;
-        if (val == 0) {
-          pflib_log(debug) << "Channel " << ch
-                           << " is above target but too close to use DACB to "
-                              "lower, skipping";
-        } else {
-          pflib_log(debug) << "Channel " << ch
-                           << " is above target, setting SIGN_DAC=1 and DACB";
-          settings[i_roc][page]["SIGN_DAC"] = 1;
-          settings[i_roc][page]["DACB"] = val;
+        if (scale > 1 && !pftool::state.readout_config_is_hcal() ) {
+          pflib_log(warn)
+            << "Channel " << ch
+            << " is so far above target that we cannot lower it enough."
+		    << " Setting TRIM_INV = 0.";
+		  settings[i_roc][page]["TRIM_INV"] = 0;
+          continue;
         }
-      }
-    }
-  }
+		// scale is in [0,1]
+		double diff = static_cast<double>(baseline[i_roc].at(ch) -
+                                         target[i_roc].at(i_half));
+		if ( pftool::state.readout_config_is_hcal() ) {
+		  double trim_diff = static_cast<double>(baseline[i_roc].at(ch) -
+                                                allzero[i_roc].at(ch));
+		  double dacb_diff = static_cast<double>(allzero[i_roc].at(ch) -
+                                                lowend[i_roc].at(ch));
+		  if (trim_diff < 0 || dacb_diff < 0) {
+		    pflib_log(debug) << "Channel " << ch
+							 << " is above target but lowering TRIM_INV "
+							 << "or setting SIGN_DAC = 1 and raising DACB"
+							 << " made it higher??? Skipping...";
+			continue;
+		  }
+		  if (diff <= trim_diff) {
+		    double optim = 32 - ( (diff / trim_diff) * 32 );
+			uint64_t val = static_cast<uint64_t>(optim);
+            pflib_log(trace) << "Scale " << (diff/trim_diff)
+							 << " giving optimal value of "
+                             << optim << " for TRIM_INV" 
+							    " which rounds to " << val;
+		    if (val ==0 ) {
+              pflib_log(debug) << "Channel " << ch
+                               << " is above target but too close to use TRIM_INV "
+                                  "to lower, skipping.";
+			} else {
+			  pflib_log(debug) << "Channel " << ch
+                               << " is above target, lowering TRIM_INV";
+			  settings[i_roc][page]["TRIM_INV"] = val;
+			}
+	      }
+		  else /* diff > trim_diff */ {
+            double optim = ( (diff - trim_diff) / dacb_diff ) * 31;
+			uint64_t val = static_cast<uint64_t>(optim);
+            pflib_log(trace) << "Scale " << ((diff-trim_diff)/dacb_diff)
+							 << " giving optimal value of "
+                             << optim << " for DACB"
+							    " which rounds to " << val;
+			if (val == 0) {
+			  pflib_log(debug) << "Channel " << ch
+							   << " is above target but too close to use DACB "
+								  "to lower. Setting TRIM_INV = 0";
+			  settings[i_roc][page]["TRIM_INV"] = 0;
+			} else {
+			  pflib_log(debug) << "Channel" << ch
+							   << " is above target, setting TRIM_INV = 0."
+								  " Setting SIGN_DAC = 1 and DACB.";
+			  settings[i_roc][page]["TRIM_INV"] = 0;
+			  settings[i_roc][page]["SIGN_DAC"] = 1;
+			  settings[i_roc][page]["DACB"] = val;
+            }
+		  }
+        }
+		else /* ecal */ {
+		  double trim_diff = static_cast<double>(baseline[i_roc].at(ch) -
+                                                lowend[i_roc].at(ch));
+		  double optim = 32 - ( scale * 32 );
+		  uint64_t val = static_cast<uint64_t>(optim);
+	      pflib_log(trace) << "Scale " << (diff/trim_diff)
+							 << " giving optimal value of "
+                             << optim << " for TRIM_INV"
+							    " which rounds to " << val;
+		  if (val == 0) {
+		    pflib_log(debug) << "Channel" << ch
+						     << " is above target but too close to use TRIM_INV "
+								"to lower, skipping.";
+		  } else {
+		    pflib_log(debug) << "Channel" << ch
+						     << " is above target, setting TRIM_INV.";
+		    settings[i_roc][page]["TRIM_INV"] = val;
+		  } 
+		} // end if ecal
+      } // end if baseline > target
+    } // end loop over channels
+  } // end loop over rocs
 
   return settings;
 }

--- a/app/tool/bias.cxx
+++ b/app/tool/bias.cxx
@@ -29,8 +29,9 @@ static void bias(const std::string& cmd, pflib::HcalTarget* pft) {
     double temp = bias.readTemp();
     std::cout << "Board temperature: " << temp << " C" << std::endl;
     for (int ch = 0; ch < 16; ch++) {
-      std::cout << "Channel " << std::setw(2) << ch << " SiPM DAC " << bias.readSiPM(ch)
-                << " LED DAC " << bias.readLED(ch) << std::endl;
+      std::cout << "Channel " << std::setw(2) << ch << " SiPM DAC "
+                << bias.readSiPM(ch) << " LED DAC " << bias.readLED(ch)
+                << std::endl;
     }
   }
   if (cmd == "READ_SIPM") {


### PR DESCRIPTION
Opening a PR but may need to do some extra work before merging.

For local pedestal leveling, change baseline `TRIM_INV` from `0` to `32`, add adaptive support for both `ECAL` and `HCAL` ROCs, and mask dead channels (i.e., those with 0 standard deviation).  Seeing some difficulty leveling for ECAL (see image). May just be running out of range with `TRIM_INV`, but someone should try to run this on their own to verify behavior. 

Note: did not yet test for HCAL

<img width="500" height="1200" alt="ecal_smm_pedestal_local" src="https://github.com/user-attachments/assets/ff384e46-1628-483d-9416-0935f4cf7f24" />

