### PR TITLE
linearize sums in firmware, more firmware histograms

### DIFF
--- a/ana/plot-fw-histograms.py
+++ b/ana/plot-fw-histograms.py
@@ -19,6 +19,7 @@ parser.add_argument('--error-bars', action='store_true', help='show error bars i
 parser.add_argument('--stc', type=int, help='only plot input STC if given')
 parser.add_argument('--roc-adc-th', type=int, help='digitalhalf_#.adc_th setting on the ROCs being used')
 parser.add_argument('--trigger-th', type=int, help='trigger threshold being used')
+parser.add_argument('--decoder-lut-scale', type=int, help='scale division loaded into decoder lut')
 parser.add_argument('--raw-counts', action='store_true', help='plot raw counts instead of scaling by collection time to estimate the rate')
 args = parser.parse_args()
 
@@ -42,6 +43,9 @@ if args.stc is not None and len(h.axes) > 1:
     )
 else:
     h.plot(yerr = args.error_bars)
+
+if args.decoder_lut_scale is not None:
+    plt.xlabel(plt.gca().get_xlabel() + f' / {args.decoder_lut_scale}')
 
 vlines = []
 if args.roc_adc_th is not None:

--- a/app/tool/trig/FWHistoPool.cxx
+++ b/app/tool/trig/FWHistoPool.cxx
@@ -11,7 +11,8 @@ static constexpr uint32_t MASK_HISTO_CLEAR = 0x4;
 
 uint32_t FWHistoPool::FW_VERSION = 0;
 
-std::optional<double> FWHistoPool::get_collection_time(FWHistoPool::a_time_point now) const {
+std::optional<double> FWHistoPool::get_collection_time(
+    FWHistoPool::a_time_point now) const {
   using namespace std::literals;
   if (time_of_last_clear_) {
     return (now - time_of_last_clear_.value()) / 1.0s;
@@ -23,14 +24,15 @@ std::optional<double> FWHistoPool::get_collection_time(FWHistoPool::a_time_point
   }
 }
 
-std::array<uint32_t, 256> FWHistoPool::read_fw(FWHistoPool::FillValue fill_type, int index) {
+std::array<uint32_t, 256> FWHistoPool::read_fw(FWHistoPool::FillValue fill_type,
+                                               int index) {
   uint32_t quad_addr, quad_index{static_cast<uint32_t>(index % 4)};
   if (fill_type == FWHistoPool::FillValue::DecodedSum) {
-    quad_addr = (0xC00 + 4*0x10 + 4*(index / 4)) / 4;
+    quad_addr = (0xC00 + 4 * 0x10 + 4 * (index / 4)) / 4;
   } else if (fill_type == FWHistoPool::FillValue::EncodedSum) {
-    quad_addr = (0xC00 + 4*0x12 + 4*(index / 4)) / 4;
+    quad_addr = (0xC00 + 4 * 0x12 + 4 * (index / 4)) / 4;
   } else if (fill_type == FWHistoPool::FillValue::HighPeak) {
-    quad_addr = (0xC00 + 4*0x14 + 4*(index / 4)) / 4;
+    quad_addr = (0xC00 + 4 * 0x14 + 4 * (index / 4)) / 4;
   } else if (fill_type == FWHistoPool::FillValue::Test) {
     // only one quad for test histogram
     quad_addr = 0xC7C / 4;
@@ -73,21 +75,21 @@ void FWHistoPool::debug(int fill_val) {
 }
 
 FWHistoPool::SingleChannelHistogram::SingleChannelHistogram(
-  FillValue fill_type, int index, std::array<uint32_t, 256> values, double collection_time)
-  : fill_type_{fill_type},
-    index_{index},
-    values_{values},
-    collection_time_{collection_time} {}
+    FillValue fill_type, int index, std::array<uint32_t, 256> values,
+    double collection_time)
+    : fill_type_{fill_type},
+      index_{index},
+      values_{values},
+      collection_time_{collection_time} {}
 
 FWHistoPool::FillValue FWHistoPool::SingleChannelHistogram::fill_type() const {
   return fill_type_;
 }
 
-int FWHistoPool::SingleChannelHistogram::index() const {
-  return index_;
-}
+int FWHistoPool::SingleChannelHistogram::index() const { return index_; }
 
-const std::array<uint32_t, 256> FWHistoPool::SingleChannelHistogram::values() const {
+const std::array<uint32_t, 256> FWHistoPool::SingleChannelHistogram::values()
+    const {
   return values_;
 }
 
@@ -96,18 +98,16 @@ double FWHistoPool::SingleChannelHistogram::collection_time() const {
 }
 
 static const std::unordered_map<FWHistoPool::FillValue, std::string> LABELS = {
-  {FWHistoPool::FillValue::EncodedSum, "Encoded Sum"},
-  {FWHistoPool::FillValue::DecodedSum, "Decoded Sum"},
-  {FWHistoPool::FillValue::HighPeak, "High Peak"},
-  {FWHistoPool::FillValue::Test, "Test Fill Code"}
-};
+    {FWHistoPool::FillValue::EncodedSum, "Encoded Sum"},
+    {FWHistoPool::FillValue::DecodedSum, "Decoded Sum"},
+    {FWHistoPool::FillValue::HighPeak, "High Peak"},
+    {FWHistoPool::FillValue::Test, "Test Fill Code"}};
 
 static const std::unordered_map<FWHistoPool::FillValue, std::string> NAMES = {
-  {FWHistoPool::FillValue::EncodedSum, "encoded_sum"},
-  {FWHistoPool::FillValue::DecodedSum, "decoded_sum"},
-  {FWHistoPool::FillValue::HighPeak, "high_peak"},
-  {FWHistoPool::FillValue::Test, "test_fill_code"}
-};
+    {FWHistoPool::FillValue::EncodedSum, "encoded_sum"},
+    {FWHistoPool::FillValue::DecodedSum, "decoded_sum"},
+    {FWHistoPool::FillValue::HighPeak, "high_peak"},
+    {FWHistoPool::FillValue::Test, "test_fill_code"}};
 
 nlohmann::json FWHistoPool::SingleChannelHistogram::to_json() const {
   nlohmann::json hist;
@@ -141,7 +141,8 @@ nlohmann::json FWHistoPool::SingleChannelHistogram::to_json() const {
   return hist;
 }
 
-FWHistoPool::SingleChannelHistogram FWHistoPool::read(FWHistoPool::FillValue fill_type, int index) {
+FWHistoPool::SingleChannelHistogram FWHistoPool::read(
+    FWHistoPool::FillValue fill_type, int index) {
   if (index < 0 or index > 7) {
     PFEXCEPTION_RAISE("OutOfRange",
                       "Provided histogram index " + std::to_string(index) +
@@ -149,21 +150,23 @@ FWHistoPool::SingleChannelHistogram FWHistoPool::read(FWHistoPool::FillValue fil
   }
 
   return SingleChannelHistogram(
-    fill_type, index, read_fw(fill_type, index), get_collection_time(the_clock::now()).value_or(0)
-  );
+      fill_type, index, read_fw(fill_type, index),
+      get_collection_time(the_clock::now()).value_or(0));
 }
 
 FWHistoPool::BlockHistogram::BlockHistogram(
-  FillValue fill_type, std::array<std::array<uint32_t, 256>,8> values, double collection_time)
-  : fill_type_{fill_type},
-    values_{values},
-    collection_time_{collection_time} {}
+    FillValue fill_type, std::array<std::array<uint32_t, 256>, 8> values,
+    double collection_time)
+    : fill_type_{fill_type},
+      values_{values},
+      collection_time_{collection_time} {}
 
 FWHistoPool::FillValue FWHistoPool::BlockHistogram::fill_type() const {
   return fill_type_;
 }
 
-const std::array<std::array<uint32_t, 256>,8> FWHistoPool::BlockHistogram::values() const {
+const std::array<std::array<uint32_t, 256>, 8>
+FWHistoPool::BlockHistogram::values() const {
   return values_;
 }
 

--- a/app/tool/trig/FWHistoPool.cxx
+++ b/app/tool/trig/FWHistoPool.cxx
@@ -40,10 +40,10 @@ void FWHistoPool::debug(int fill_val) {
 }
 
 std::array<uint32_t, 256> FWHistoPool::read(int ihist) {
-  if (ihist < 0 or ihist > 11) {
+  if (ihist < 0 or ihist > 19) {
     PFEXCEPTION_RAISE("OutOfRange",
                       "Provided histogram index " + std::to_string(ihist) +
-                          " but the FWHistoPool only supports indices [0,11]");
+                          " but the FWHistoPool only supports indices [0,19]");
   }
   int block = ihist / 4;
   uint32_t data_addr = 0;
@@ -86,13 +86,21 @@ nlohmann::json FWHistoPool::to_json(const std::array<uint32_t, 256>& data,
   axis["overflow"] = false;
   axis["circular"] = false;
   std::string name;
-  if (ihist < 8) {
-    name = string_format("STC%d", ihist);
+  if (ihist < 16) {
+    name = string_format("STC%d", ihist % 8);
   } else {
-    name = string_format("TEST%d", ihist - 8);
+    name = string_format("TEST%d", ihist % 8);
   }
   axis["metadata"]["name"] = name;
-  axis["metadata"]["label"] = name + " Encoded Sum";
+  std::string label = name;
+  if (ihist < 8) {
+    name += "Decoded Sum";
+  } else if (ihist < 16) {
+    name += "Encoded Sum";
+  } else {
+    name += "STB Fill Code";
+  }
+  axis["metadata"]["label"] = label;
 
   hist["axes"] = {axis};
   hist["storage"]["type"] = "double";
@@ -102,6 +110,7 @@ nlohmann::json FWHistoPool::to_json(const std::array<uint32_t, 256>& data,
 
 nlohmann::json FWHistoPool::to_json(
     const std::array<std::array<uint32_t, 256>, 8>& data,
+    bool decoded,
     double collection_time) {
   nlohmann::json hist;
   hist["uhi_schema"] = 1;
@@ -127,8 +136,13 @@ nlohmann::json FWHistoPool::to_json(
   reg["underflow"] = false;
   reg["overflow"] = false;
   reg["circular"] = false;
-  reg["metadata"]["name"] = "encoded_sum";
-  reg["metadata"]["label"] = "Encoded Sum";
+  if (decoded) {
+    reg["metadata"]["name"] = "decoded_sum";
+    reg["metadata"]["label"] = "Decoded Sum";
+  } else {
+    reg["metadata"]["name"] = "encoded_sum";
+    reg["metadata"]["label"] = "Encoded Sum";
+  }
 
   hist["axes"] = {cat, reg};
   hist["storage"]["type"] = "double";

--- a/app/tool/trig/FWHistoPool.cxx
+++ b/app/tool/trig/FWHistoPool.cxx
@@ -10,6 +10,8 @@ static constexpr uint32_t ADDR_HISTO_CLEAR = 0x100 / 4;
 static constexpr uint32_t MASK_HISTO_CLEAR = 0x4;
 static constexpr uint32_t ADDR_TRIG_HISTO_03 = 0xC40 / 4;
 static constexpr uint32_t ADDR_TRIG_HISTO_47 = 0xC44 / 4;
+static constexpr uint32_t ADDR_TRIG_HISTO_ENCODED_03 = 0xC48 / 4;
+static constexpr uint32_t ADDR_TRIG_HISTO_ENCODED_47 = 0xC4C / 4;
 static constexpr uint32_t ADDR_TRIG_HISTO_TEST = 0xC7C / 4;
 
 uint32_t FWHistoPool::FW_VERSION = 0;
@@ -50,6 +52,10 @@ std::array<uint32_t, 256> FWHistoPool::read(int ihist) {
   } else if (block == 1) {
     data_addr = ADDR_TRIG_HISTO_47;
   } else if (block == 2) {
+    data_addr = ADDR_TRIG_HISTO_ENCODED_03;
+  } else if (block == 3) {
+    data_addr = ADDR_TRIG_HISTO_ENCODED_47;
+  } else if (block == 4) {
     data_addr = ADDR_TRIG_HISTO_TEST;
   }
   std::array<uint32_t, 256> data;

--- a/app/tool/trig/FWHistoPool.cxx
+++ b/app/tool/trig/FWHistoPool.cxx
@@ -16,18 +16,62 @@ static constexpr uint32_t ADDR_TRIG_HISTO_TEST = 0xC7C / 4;
 
 uint32_t FWHistoPool::FW_VERSION = 0;
 
+std::optional<double> FWHistoPool::get_collection_time(FWHistoPool::a_time_point now) const {
+  using namespace std::literals;
+  if (time_of_last_clear_) {
+    return (now - time_of_last_clear_.value()) / 1.0s;
+  } else {
+    pflib_log(warn) << "There hasn't be a CLEAR recently,"
+                       " so we don't know the collection time and"
+                       " the histograms are probably saturated!";
+    return {};
+  }
+}
+
+std::array<uint32_t, 256> FWHistoPool::read_fw(FWHistoPool::FillValue fill_type, int index) {
+  uint32_t quad_addr, quad_index{static_cast<uint32_t>(index % 4)};
+  if (fill_type == FWHistoPool::FillValue::DecodedSum) {
+    if (index < 4) {
+      quad_addr = ADDR_TRIG_HISTO_03;
+    } else {
+      quad_addr = ADDR_TRIG_HISTO_47;
+    }
+  } else if (fill_type == FWHistoPool::FillValue::EncodedSum) {
+    if (index < 4) {
+      quad_addr = ADDR_TRIG_HISTO_ENCODED_03;
+    } else {
+      quad_addr = ADDR_TRIG_HISTO_ENCODED_47;
+    }
+  } else if (fill_type == FWHistoPool::FillValue::Test) {
+    // only one quad for test histogram
+    quad_addr = ADDR_TRIG_HISTO_TEST;
+  }
+  std::array<uint32_t, 256> data;
+  for (int i{0}; i < data.size(); i++) {
+    uint32_t val = i | (quad_index << 8);
+    uio_.writeMasked(ADDR_REG, ADDR_MASK, val);
+    data[i] = uio_.read(quad_addr);
+  }
+  return data;
+}
+
 FWHistoPool::FWHistoPool(int i_trigpath)
-    : uio_{string_format("trigpath-%d", i_trigpath)} {
+    : uio_{string_format("trigpath-%d", i_trigpath)},
+      time_of_last_clear_{},
+      the_log_{pflib::logging::get("pftool.trig.histo")} {
   FW_VERSION = (uio_.read(0) & 0xffff);
 }
 
-void FWHistoPool::clear() { uio_.write(ADDR_HISTO_CLEAR, MASK_HISTO_CLEAR); }
+void FWHistoPool::clear() {
+  uio_.write(ADDR_HISTO_CLEAR, MASK_HISTO_CLEAR);
+  time_of_last_clear_ = the_clock::now();
+}
 
 void FWHistoPool::debug(int fill_val) {
   uio_.write(ADDR_HISTO_CLEAR, (fill_val & 0xFF) << 8);
   std::array<std::array<uint32_t, 256>, 4> hists;
   for (int i{0}; i < 4; i++) {
-    hists[i] = read(8 + i);
+    hists[i] = read_fw(FWHistoPool::FillValue::Test, i);
   }
   printf("bin: %10u %10u %10u %10u\n", 0, 1, 2, 3);
   for (int i{0}; i < 256; i++) {
@@ -39,86 +83,111 @@ void FWHistoPool::debug(int fill_val) {
   }
 }
 
-std::array<uint32_t, 256> FWHistoPool::read(int ihist) {
-  if (ihist < 0 or ihist > 19) {
-    PFEXCEPTION_RAISE("OutOfRange",
-                      "Provided histogram index " + std::to_string(ihist) +
-                          " but the FWHistoPool only supports indices [0,19]");
-  }
-  int block = ihist / 4;
-  uint32_t data_addr = 0;
-  if (block == 0) {
-    data_addr = ADDR_TRIG_HISTO_03;
-  } else if (block == 1) {
-    data_addr = ADDR_TRIG_HISTO_47;
-  } else if (block == 2) {
-    data_addr = ADDR_TRIG_HISTO_ENCODED_03;
-  } else if (block == 3) {
-    data_addr = ADDR_TRIG_HISTO_ENCODED_47;
-  } else if (block == 4) {
-    data_addr = ADDR_TRIG_HISTO_TEST;
-  }
-  std::array<uint32_t, 256> data;
-  for (int i{0}; i < data.size(); i++) {
-    uint32_t val = i | (ihist << 8);
-    uio_.writeMasked(ADDR_REG, ADDR_MASK, val);
-    data[i] = uio_.read(data_addr);
-  }
-  return data;
+FWHistoPool::SingleChannelHistogram::SingleChannelHistogram(
+  FillValue fill_type, int index, std::array<uint32_t, 256> values, double collection_time)
+  : fill_type_{fill_type},
+    index_{index},
+    values_{values},
+    collection_time_{collection_time} {}
+
+FWHistoPool::FillValue FWHistoPool::SingleChannelHistogram::fill_type() const {
+  return fill_type_;
 }
 
-nlohmann::json FWHistoPool::to_json(const std::array<uint32_t, 256>& data,
-                                    int ihist, double collection_time) {
+int FWHistoPool::SingleChannelHistogram::index() const {
+  return index_;
+}
+
+const std::array<uint32_t, 256> FWHistoPool::SingleChannelHistogram::values() const {
+  return values_;
+}
+
+double FWHistoPool::SingleChannelHistogram::collection_time() const {
+  return collection_time_;
+}
+
+static const std::unordered_map<FWHistoPool::FillValue, std::string> LABELS = {
+  {FWHistoPool::FillValue::EncodedSum, "Encoded Sum"},
+  {FWHistoPool::FillValue::DecodedSum, "Decoded Sum"},
+  {FWHistoPool::FillValue::Test, "Test Fill Code"}
+};
+
+static const std::unordered_map<FWHistoPool::FillValue, std::string> NAMES = {
+  {FWHistoPool::FillValue::EncodedSum, "encoded_sum"},
+  {FWHistoPool::FillValue::DecodedSum, "decoded_sum"},
+  {FWHistoPool::FillValue::Test, "test_fill_code"}
+};
+
+nlohmann::json FWHistoPool::SingleChannelHistogram::to_json() const {
   nlohmann::json hist;
   hist["uhi_schema"] = 1;
   hist["writer_info"]["pftool.FWHistoPool"]["version"] =
       pflib::version::debug();
   hist["writer_info"]["trigpath-firmware"]["version"] = FW_VERSION;
   hist["metadata"]["_variance_known"] = true;
-  hist["metadata"]["collection_time"] = collection_time;
+  hist["metadata"]["collection_time"] = collection_time_;
 
   nlohmann::json axis;
   axis["type"] = "regular";
   axis["lower"] = 0.0;
-  axis["upper"] = data.size();
-  axis["bins"] = data.size();
+  axis["upper"] = values_.size();
+  axis["bins"] = values_.size();
   axis["underflow"] = false;
   axis["overflow"] = false;
   axis["circular"] = false;
   std::string name;
-  if (ihist < 16) {
-    name = string_format("STC%d", ihist % 8);
+  if (fill_type_ == FWHistoPool::FillValue::Test) {
+    name = string_format("TEST%d", index_);
   } else {
-    name = string_format("TEST%d", ihist % 8);
+    name = string_format("STC%d", index_);
   }
   axis["metadata"]["name"] = name;
-  std::string label = name;
-  if (ihist < 8) {
-    name += "Decoded Sum";
-  } else if (ihist < 16) {
-    name += "Encoded Sum";
-  } else {
-    name += "STB Fill Code";
-  }
-  axis["metadata"]["label"] = label;
+  axis["metadata"]["label"] = name + LABELS.at(fill_type_);
 
   hist["axes"] = {axis};
   hist["storage"]["type"] = "double";
-  hist["storage"]["values"] = data;
+  hist["storage"]["values"] = values_;
   return hist;
 }
 
-nlohmann::json FWHistoPool::to_json(
-    const std::array<std::array<uint32_t, 256>, 8>& data,
-    bool decoded,
-    double collection_time) {
+FWHistoPool::SingleChannelHistogram FWHistoPool::read(FWHistoPool::FillValue fill_type, int index) {
+  if (index < 0 or index > 7) {
+    PFEXCEPTION_RAISE("OutOfRange",
+                      "Provided histogram index " + std::to_string(index) +
+                          " but the FWHistoPool only supports indices [0,7]");
+  }
+
+  return SingleChannelHistogram(
+    fill_type, index, read_fw(fill_type, index), get_collection_time(the_clock::now()).value_or(0)
+  );
+}
+
+FWHistoPool::BlockHistogram::BlockHistogram(
+  FillValue fill_type, std::array<std::array<uint32_t, 256>,8> values, double collection_time)
+  : fill_type_{fill_type},
+    values_{values},
+    collection_time_{collection_time} {}
+
+FWHistoPool::FillValue FWHistoPool::BlockHistogram::fill_type() const {
+  return fill_type_;
+}
+
+const std::array<std::array<uint32_t, 256>,8> FWHistoPool::BlockHistogram::values() const {
+  return values_;
+}
+
+double FWHistoPool::BlockHistogram::collection_time() const {
+  return collection_time_;
+}
+
+nlohmann::json FWHistoPool::BlockHistogram::to_json() const {
   nlohmann::json hist;
   hist["uhi_schema"] = 1;
   hist["writer_info"]["pftool.FWHistoPool"]["version"] =
       pflib::version::debug();
   hist["writer_info"]["trigpath-firmware"]["version"] = FW_VERSION;
   hist["metadata"]["_variance_known"] = true;
-  hist["metadata"]["collection_time"] = collection_time;
+  hist["metadata"]["collection_time"] = collection_time_;
 
   nlohmann::json cat;
   cat["type"] = "category_str";
@@ -136,16 +205,20 @@ nlohmann::json FWHistoPool::to_json(
   reg["underflow"] = false;
   reg["overflow"] = false;
   reg["circular"] = false;
-  if (decoded) {
-    reg["metadata"]["name"] = "decoded_sum";
-    reg["metadata"]["label"] = "Decoded Sum";
-  } else {
-    reg["metadata"]["name"] = "encoded_sum";
-    reg["metadata"]["label"] = "Encoded Sum";
-  }
+  reg["metadata"]["name"] = NAMES.at(fill_type_);
+  reg["metadata"]["label"] = LABELS.at(fill_type_);
 
   hist["axes"] = {cat, reg};
   hist["storage"]["type"] = "double";
-  hist["storage"]["values"] = data;
+  hist["storage"]["values"] = values_;
   return hist;
+}
+
+FWHistoPool::BlockHistogram FWHistoPool::read(FillValue fill_type) {
+  auto colltime = get_collection_time(the_clock::now());
+  std::array<std::array<uint32_t, 256>, 8> content;
+  for (int ihist{0}; ihist < 8; ihist++) {
+    content[ihist] = read_fw(fill_type, ihist);
+  }
+  return BlockHistogram(fill_type, content, colltime.value_or(0));
 }

--- a/app/tool/trig/FWHistoPool.cxx
+++ b/app/tool/trig/FWHistoPool.cxx
@@ -8,11 +8,6 @@ using pflib::utility::string_format;
 
 static constexpr uint32_t ADDR_HISTO_CLEAR = 0x100 / 4;
 static constexpr uint32_t MASK_HISTO_CLEAR = 0x4;
-static constexpr uint32_t ADDR_TRIG_HISTO_03 = 0xC40 / 4;
-static constexpr uint32_t ADDR_TRIG_HISTO_47 = 0xC44 / 4;
-static constexpr uint32_t ADDR_TRIG_HISTO_ENCODED_03 = 0xC48 / 4;
-static constexpr uint32_t ADDR_TRIG_HISTO_ENCODED_47 = 0xC4C / 4;
-static constexpr uint32_t ADDR_TRIG_HISTO_TEST = 0xC7C / 4;
 
 uint32_t FWHistoPool::FW_VERSION = 0;
 
@@ -31,20 +26,14 @@ std::optional<double> FWHistoPool::get_collection_time(FWHistoPool::a_time_point
 std::array<uint32_t, 256> FWHistoPool::read_fw(FWHistoPool::FillValue fill_type, int index) {
   uint32_t quad_addr, quad_index{static_cast<uint32_t>(index % 4)};
   if (fill_type == FWHistoPool::FillValue::DecodedSum) {
-    if (index < 4) {
-      quad_addr = ADDR_TRIG_HISTO_03;
-    } else {
-      quad_addr = ADDR_TRIG_HISTO_47;
-    }
+    quad_addr = (0xC00 + 4*0x10 + 4*(index / 4)) / 4;
   } else if (fill_type == FWHistoPool::FillValue::EncodedSum) {
-    if (index < 4) {
-      quad_addr = ADDR_TRIG_HISTO_ENCODED_03;
-    } else {
-      quad_addr = ADDR_TRIG_HISTO_ENCODED_47;
-    }
+    quad_addr = (0xC00 + 4*0x12 + 4*(index / 4)) / 4;
+  } else if (fill_type == FWHistoPool::FillValue::HighPeak) {
+    quad_addr = (0xC00 + 4*0x14 + 4*(index / 4)) / 4;
   } else if (fill_type == FWHistoPool::FillValue::Test) {
     // only one quad for test histogram
-    quad_addr = ADDR_TRIG_HISTO_TEST;
+    quad_addr = 0xC7C / 4;
   }
   std::array<uint32_t, 256> data;
   for (int i{0}; i < data.size(); i++) {
@@ -109,12 +98,14 @@ double FWHistoPool::SingleChannelHistogram::collection_time() const {
 static const std::unordered_map<FWHistoPool::FillValue, std::string> LABELS = {
   {FWHistoPool::FillValue::EncodedSum, "Encoded Sum"},
   {FWHistoPool::FillValue::DecodedSum, "Decoded Sum"},
+  {FWHistoPool::FillValue::HighPeak, "High Peak"},
   {FWHistoPool::FillValue::Test, "Test Fill Code"}
 };
 
 static const std::unordered_map<FWHistoPool::FillValue, std::string> NAMES = {
   {FWHistoPool::FillValue::EncodedSum, "encoded_sum"},
   {FWHistoPool::FillValue::DecodedSum, "decoded_sum"},
+  {FWHistoPool::FillValue::HighPeak, "high_peak"},
   {FWHistoPool::FillValue::Test, "test_fill_code"}
 };
 

--- a/app/tool/trig/FWHistoPool.h
+++ b/app/tool/trig/FWHistoPool.h
@@ -6,8 +6,8 @@
 #include <nlohmann/json.hpp>
 #include <optional>
 
-#include "pflib/zcu/UIO.h"
 #include "pflib/logging/Logging.h"
+#include "pflib/zcu/UIO.h"
 
 /**
  * read and print histograms filled by the firmware
@@ -100,8 +100,11 @@ class FWHistoPool {
     std::array<uint32_t, 256> values_;
     /// time histogram was filling in seconds (or zero if no last clear)
     double collection_time_;
+
    public:
-    SingleChannelHistogram(FillValue fill_type, int index, std::array<uint32_t, 256> values, double collection_time);
+    SingleChannelHistogram(FillValue fill_type, int index,
+                           std::array<uint32_t, 256> values,
+                           double collection_time);
     /// which type of fill value was put into the histogram
     FillValue fill_type() const;
     /// which index was read
@@ -155,8 +158,11 @@ class FWHistoPool {
     std::array<std::array<uint32_t, 256>, 8> values_;
     /// time histogram was filling in seconds (or zero if no last clear)
     double collection_time_;
+
    public:
-    BlockHistogram(FillValue fill_type, std::array<std::array<uint32_t, 256>, 8> values, double collection_time);
+    BlockHistogram(FillValue fill_type,
+                   std::array<std::array<uint32_t, 256>, 8> values,
+                   double collection_time);
     /// which type of fill value was put into the histogram
     FillValue fill_type() const;
     /// access the values of the histogram

--- a/app/tool/trig/FWHistoPool.h
+++ b/app/tool/trig/FWHistoPool.h
@@ -108,13 +108,16 @@ class FWHistoPool {
    * ```
    *
    * @param[in] data set of histograms to serialize into JSON
+   * @param[in] whether to label the axis for the sums as decoded (true)
+   * or encoded (false)
    * @param[in] collection_time time in s that data was collected,
-   * included in the histograms 'metadata' in the JSON for scaling
+   * included in the histogram's 'metadata' in the JSON for scaling
    * the plot later if desired
    * @return JSON representation of list of histograms
    */
   static nlohmann::json to_json(
       const std::array<std::array<uint32_t, 256>, 8>& data,
+      bool decoded,
       double collection_time);
 };
 

--- a/app/tool/trig/FWHistoPool.h
+++ b/app/tool/trig/FWHistoPool.h
@@ -73,8 +73,10 @@ class FWHistoPool {
     DecodedSum = 0,
     /// the sums as unpacked but still in their 5E+4M encoding
     EncodedSum = 1,
+    /// value of rolling sum, high peaks used for trigger
+    HighPeak = 2,
     /// the test histogram codes
-    Test = 2
+    Test = 15
   };
 
   /**

--- a/app/tool/trig/FWHistoPool.h
+++ b/app/tool/trig/FWHistoPool.h
@@ -7,6 +7,7 @@
 #include <optional>
 
 #include "pflib/zcu/UIO.h"
+#include "pflib/logging/Logging.h"
 
 /**
  * read and print histograms filled by the firmware
@@ -21,11 +22,26 @@ class FWHistoPool {
   /// handle to register area of trigpath firmware block
   pflib::UIO uio_;
 
+  /// type of clock we'll use to measure collection time
+  using the_clock = std::chrono::high_resolution_clock;
+  /// a time point for our clock
+  using a_time_point = std::chrono::time_point<the_clock>;
+  /// last time the clear method was called
+  std::optional<a_time_point> time_of_last_clear_;
+
+  /// share logging channel with histo menu
+  mutable pflib::logging::logger the_log_;
+
+  /// get the collection time
+  std::optional<double> get_collection_time(a_time_point now) const;
+
  public:
   /// construct the pool for the passed trigpath index (0 or 1)
   FWHistoPool(int i_trigpath);
+
   /// reset all of the histograms in the pool to zero counts
   void clear();
+
   /**
    * use the test histograms to check the functionality of the histogram block
    *
@@ -49,76 +65,138 @@ class FWHistoPool {
   void debug(int fill_val);
 
   /**
+   * the blocks of histograms are logically distinct by
+   * what values we fill into them
+   */
+  enum class FillValue : int {
+    /// the sums as output by the decoder lut
+    DecodedSum = 0,
+    /// the sums as unpacked but still in their 5E+4M encoding
+    EncodedSum = 1,
+    /// the test histogram codes
+    Test = 2
+  };
+
+  /**
+   * read a histogram's content from the firmware
+   *
+   * @param[in] fill_type block of histograms to read from
+   * @param[in] index index of the histogram we want in that block
+   * @return histogram content
+   */
+  std::array<uint32_t, 256> read_fw(FillValue fill_type, int index);
+
+  /**
+   * A single histogram read into memory
+   */
+  class SingleChannelHistogram {
+    /// what type of value was filled into the histogram
+    FillValue fill_type_;
+    /// index of STC in this histogram
+    int index_;
+    /// content of the histogram
+    std::array<uint32_t, 256> values_;
+    /// time histogram was filling in seconds (or zero if no last clear)
+    double collection_time_;
+   public:
+    SingleChannelHistogram(FillValue fill_type, int index, std::array<uint32_t, 256> values, double collection_time);
+    /// which type of fill value was put into the histogram
+    FillValue fill_type() const;
+    /// which index was read
+    int index() const;
+    /// access the values of the histogram
+    const std::array<uint32_t, 256> values() const;
+    /// how long was the histogram being filled?
+    double collection_time() const;
+    /**
+     * convert the histogram into
+     * [UHI JSON](https://uhi.readthedocs.io/en/latest/serialization.html#json)
+     *
+     * This JSON output is helpful for loading into python plotting.
+     * If only the output from this function is written to the file,
+     * then the histogram can be loaded with
+     * ```python
+     * import json
+     * import uhi.io.json
+     * import hist
+     *
+     * with open('path/to/hist.json') as f:
+     *     h_ir = json.load(f, object_hook=uhi.io.json.object_hook)
+     *
+     * h = hist.Hist(h_ir)
+     * # h is a 1D histogram of the STC sum
+     * ```
+     *
+     * @return JSON representation of histogram
+     */
+    nlohmann::json to_json() const;
+  };
+
+  /**
    * read the current values for the input histogram index
+   * of the input value type
    *
-   * The first eight indices [0,7] map onto the associated STCs.
-   * The next four [8,11] are the four test histograms.
-   *
-   * @return the current histogram values as an array
+   * @param[in] fill_type FillValue choosing which block of histograms
+   * to read from
+   * @param[in] ihist index of histogram within that block [0,7]
+   * @return the current histogram
    */
-  std::array<uint32_t, 256> read(int ihist);
+  SingleChannelHistogram read(FillValue fill_type, int ihist);
 
   /**
-   * convert the input array and histogram index into
-   * [UHI JSON](https://uhi.readthedocs.io/en/latest/serialization.html#json)
-   *
-   * This JSON output is helpful for loading into python plotting.
-   * If only the output from this function is written to the file,
-   * then the histogram can be loaded with
-   * ```python
-   * import json
-   * import uhi.io.json
-   * import hist
-   *
-   * with open('path/to/hist.json') as f:
-   *     h_ir = json.load(f, object_hook=uhi.io.json.object_hook)
-   *
-   * h = hist.Hist(h_ir)
-   * # h is a 1D histogram of the STC sum
-   * ```
-   *
-   * @param[in] hist histogram to serialize into UHI JSON
-   * @param[in] ihist histogram index to include in labeling
-   * @param[in] collection_time time in s that data was collected,
-   * included in the histograms 'metadata' in the JSON for scaling
-   * the plot later if desired
-   * @return JSON representation of histogram
+   * a full histogram block read into memory
    */
-  static nlohmann::json to_json(const std::array<uint32_t, 256>& hist,
-                                int ihist, double collection_time);
+  class BlockHistogram {
+    /// what type of value was filled into the histogram
+    FillValue fill_type_;
+    /// content of the histogram
+    std::array<std::array<uint32_t, 256>, 8> values_;
+    /// time histogram was filling in seconds (or zero if no last clear)
+    double collection_time_;
+   public:
+    BlockHistogram(FillValue fill_type, std::array<std::array<uint32_t, 256>, 8> values, double collection_time);
+    /// which type of fill value was put into the histogram
+    FillValue fill_type() const;
+    /// access the values of the histogram
+    const std::array<std::array<uint32_t, 256>, 8> values() const;
+    /// how long was the histogram being filled?
+    double collection_time() const;
+
+    /**
+     * convert the histogram into UHI JSON
+     *
+     * This JSON output is helpful for loading into python plotting.
+     * If only the output from this function is written to the file,
+     * then the histogram can be loaded with
+     * ```python
+     * import json
+     * import uhi.io.json
+     * import hist
+     *
+     * with open('path/to/hists.json') as f:
+     *     h_ir = json.load(f, object_hook=uhi.io.json.object_hook)
+     *
+     * h = hist.Hist(h_ir)
+     * # h is a 2D histogram where the first axis is the STC
+     * # and the second axis is the sum
+     * ```
+     *
+     * The collection time is included in the histogram's 'metadata'
+     * in the JSON for scaling the plot later if desired.
+     *
+     * @return JSON representation of list of histograms
+     */
+    nlohmann::json to_json() const;
+  };
 
   /**
-   * convert the input set of many histograms into a JSON
-   * list of UHI JSON histograms
+   * read the current values of a block of histograms of
+   * the input value type
    *
-   * This JSON output is helpful for loading into python plotting.
-   * If only the output from this function is written to the file,
-   * then the histogram can be loaded with
-   * ```python
-   * import json
-   * import uhi.io.json
-   * import hist
-   *
-   * with open('path/to/hists.json') as f:
-   *     h_ir = json.load(f, object_hook=uhi.io.json.object_hook)
-   *
-   * h = hist.Hist(h_ir)
-   * # h is a 2D histogram where the first axis is the STC
-   * # and the second axis is the sum
-   * ```
-   *
-   * @param[in] data set of histograms to serialize into JSON
-   * @param[in] whether to label the axis for the sums as decoded (true)
-   * or encoded (false)
-   * @param[in] collection_time time in s that data was collected,
-   * included in the histogram's 'metadata' in the JSON for scaling
-   * the plot later if desired
-   * @return JSON representation of list of histograms
+   * @param[in] fill_type FillValue choosing which block of histograms to read
+   * @return the block histogram read in
    */
-  static nlohmann::json to_json(
-      const std::array<std::array<uint32_t, 256>, 8>& data,
-      bool decoded,
-      double collection_time);
+  BlockHistogram read(FillValue fill_type);
 };
 
 #endif

--- a/app/tool/trig/histo.cxx
+++ b/app/tool/trig/histo.cxx
@@ -16,7 +16,12 @@ ENABLE_LOGGING();
 
 FWHistoPool::FillValue prompt_fill_value() {
   static int choice = 0;
-  choice = pftool::readline_int("Fill Value Options:\n  0: decoded sums\n  1: encoded sums\n  2: test hist\nWhich do you choose?", choice);
+  choice = pftool::readline_int(
+    "Fill Value Options:\n"
+    "  0: decoded sums\n"
+    "  1: encoded sums\n"
+    "  2: high peak values\n"
+    "Which do you choose?", choice);
   if (choice < 0 or choice > 2) {
     PFEXCEPTION_RAISE("BadChoice", "Chosen fill value is not one of the options");
   }
@@ -103,6 +108,9 @@ void histo(const std::string& cmd, Target* tgt) {
           break;
         case FWHistoPool::FillValue::EncodedSum:
           def_prefix += "encoded";
+          break;
+        case FWHistoPool::FillValue::HighPeak:
+          def_prefix += "highpeak";
           break;
         default:
           break;

--- a/app/tool/trig/histo.cxx
+++ b/app/tool/trig/histo.cxx
@@ -78,17 +78,16 @@ void histo(const std::string& cmd, Target* tgt) {
   }
 
   if (cmd == "DUMP") {
-    // since the histograms fill so fast,
-    // we read BEFORE asking what to write to enable a RESET->DUMP to
-    // be able to happen quickly
+    bool decoded = pftool::readline_bool("Decoded sums instead of encoded sums?", true);
     std::array<std::array<uint32_t, 256>, 8> hists;
     auto now = the_clock::now();
+    int offset{decoded?0:8};
     for (int ihist{0}; ihist < hists.size(); ihist++) {
-      hists[ihist] = hist_pool.read(ihist);
+      hists[ihist] = hist_pool.read(offset+ihist);
     }
 
     std::optional<double> collection_time = get_collection_time(now);
-    pflib_log(info) << "accumulated histogram for "
+    pflib_log(info) << "accumulated histograms for "
                     << collection_time.value_or(0) << "s";
 
     if (pftool::readline_bool("Show histograms in terminal?", true)) {
@@ -114,12 +113,14 @@ void histo(const std::string& cmd, Target* tgt) {
 
     if (pftool::readline_bool("Store histograms in JSON file for plotting?",
                               false)) {
-      auto path = pftool::readline_path("fwhist-dump", ".json");
+      std::string def_prefix{"fwhist-dump-"};
+      def_prefix += decoded?"decoded":"encoded";
+      auto path = pftool::readline_path(def_prefix, ".json");
       std::ofstream file{path};
       if (not file.is_open()) {
         PFEXCEPTION_RAISE("FileOpen", "Unable to open " + path);
       }
-      file << FWHistoPool::to_json(hists, collection_time.value_or(0));
+      file << FWHistoPool::to_json(hists, decoded, collection_time.value_or(0));
     }
   }
 }

--- a/app/tool/trig/histo.cxx
+++ b/app/tool/trig/histo.cxx
@@ -11,22 +11,16 @@
 #include "pflib/utility/string_format.h"
 
 using pflib::utility::string_format;
-using the_clock = std::chrono::high_resolution_clock;
-using a_time_point = std::chrono::time_point<the_clock>;
-static std::optional<a_time_point> time_of_last_clear{};
 
 ENABLE_LOGGING();
 
-std::optional<double> get_collection_time(a_time_point now) {
-  using namespace std::literals;
-  if (time_of_last_clear) {
-    return (now - time_of_last_clear.value()) / 1.0s;
-  } else {
-    pflib_log(warn) << "There hasn't be a CLEAR recently,"
-                       " so we don't know the collection time and"
-                       " the histograms are probably saturated!";
-    return {};
+FWHistoPool::FillValue prompt_fill_value() {
+  static int choice = 0;
+  choice = pftool::readline_int("Fill Value Options:\n  0: decoded sums\n  1: encoded sums\n  2: test hist\nWhich do you choose?", choice);
+  if (choice < 0 or choice > 2) {
+    PFEXCEPTION_RAISE("BadChoice", "Chosen fill value is not one of the options");
   }
+  return FWHistoPool::FillValue(choice);
 }
 
 void histo(const std::string& cmd, Target* tgt) {
@@ -34,7 +28,6 @@ void histo(const std::string& cmd, Target* tgt) {
 
   if (cmd == "CLEAR") {
     hist_pool.clear();
-    time_of_last_clear = the_clock::now();
   }
 
   if (cmd == "DEBUG") {
@@ -46,22 +39,20 @@ void histo(const std::string& cmd, Target* tgt) {
   if (cmd == "READ") {
     static int ihist = 0;
     ihist = pftool::readline_int("Which histogram?", ihist);
-    auto now = the_clock::now();
-    std::array<uint32_t, 256> hist = hist_pool.read(ihist);
-    std::optional<double> collection_time = get_collection_time(now);
+    auto hist = hist_pool.read(prompt_fill_value(), ihist);
     pflib_log(info) << "accumulated histogram for "
-                    << collection_time.value_or(0) << "s";
+                    << hist.collection_time() << "s";
     bool raw_counts = true;
-    if (collection_time) {
+    if (hist.collection_time() > 0) {
       raw_counts =
           pftool::readline_bool("Show raw counts (y) or rate (n)?", raw_counts);
     }
-    for (std::size_t i{0}; i < hist.size(); i++) {
+    for (std::size_t i{0}; i < hist.values().size(); i++) {
       printf("%3ld ", i);
       if (raw_counts) {
-        printf("%u", hist[i]);
+        printf("%u", hist.values()[i]);
       } else {
-        printf("%0.4e", hist[i] / collection_time.value());
+        printf("%0.4e", hist.values()[i] / hist.collection_time());
       }
       printf("\n");
     }
@@ -73,38 +64,30 @@ void histo(const std::string& cmd, Target* tgt) {
       if (not file.is_open()) {
         PFEXCEPTION_RAISE("FileOpen", "Unable to open " + path);
       }
-      file << FWHistoPool::to_json(hist, ihist, collection_time.value_or(0));
+      file << hist.to_json();
     }
   }
 
   if (cmd == "DUMP") {
-    bool decoded = pftool::readline_bool("Decoded sums instead of encoded sums?", true);
-    std::array<std::array<uint32_t, 256>, 8> hists;
-    auto now = the_clock::now();
-    int offset{decoded?0:8};
-    for (int ihist{0}; ihist < hists.size(); ihist++) {
-      hists[ihist] = hist_pool.read(offset+ihist);
-    }
-
-    std::optional<double> collection_time = get_collection_time(now);
+    auto hist = hist_pool.read(prompt_fill_value());
     pflib_log(info) << "accumulated histograms for "
-                    << collection_time.value_or(0) << "s";
+                    << hist.collection_time() << "s";
 
     if (pftool::readline_bool("Show histograms in terminal?", true)) {
       bool raw_counts = true;
-      if (collection_time) {
+      if (hist.collection_time() > 0) {
         raw_counts = pftool::readline_bool("Show raw counts (y) or rate (n)?",
                                            raw_counts);
       }
       printf("bin : %10u %10u %10u %10u %10u %10u %10u %10u\n", 0, 1, 2, 3, 4,
              5, 6, 7);
-      for (std::size_t i{0}; i < hists[0].size(); i++) {
+      for (std::size_t i{0}; i < hist.values()[0].size(); i++) {
         printf("%3ld :", i);
-        for (int ihist{0}; ihist < hists.size(); ihist++) {
+        for (int ihist{0}; ihist < hist.values().size(); ihist++) {
           if (raw_counts) {
-            printf(" %10u", hists[ihist][i]);
+            printf(" %10u", hist.values()[ihist][i]);
           } else {
-            printf(" %10.4e", hists[ihist][i] / collection_time.value());
+            printf(" %10.4e", hist.values()[ihist][i] / hist.collection_time());
           }
         }
         printf("\n");
@@ -114,13 +97,22 @@ void histo(const std::string& cmd, Target* tgt) {
     if (pftool::readline_bool("Store histograms in JSON file for plotting?",
                               false)) {
       std::string def_prefix{"fwhist-dump-"};
-      def_prefix += decoded?"decoded":"encoded";
+      switch (hist.fill_type()) {
+        case FWHistoPool::FillValue::DecodedSum:
+          def_prefix += "decoded";
+          break;
+        case FWHistoPool::FillValue::EncodedSum:
+          def_prefix += "encoded";
+          break;
+        default:
+          break;
+      }
       auto path = pftool::readline_path(def_prefix, ".json");
       std::ofstream file{path};
       if (not file.is_open()) {
         PFEXCEPTION_RAISE("FileOpen", "Unable to open " + path);
       }
-      file << FWHistoPool::to_json(hists, decoded, collection_time.value_or(0));
+      file << hist.to_json();
     }
   }
 }

--- a/app/tool/trig/histo.cxx
+++ b/app/tool/trig/histo.cxx
@@ -17,13 +17,15 @@ ENABLE_LOGGING();
 FWHistoPool::FillValue prompt_fill_value() {
   static int choice = 0;
   choice = pftool::readline_int(
-    "Fill Value Options:\n"
-    "  0: decoded sums\n"
-    "  1: encoded sums\n"
-    "  2: high peak values\n"
-    "Which do you choose?", choice);
+      "Fill Value Options:\n"
+      "  0: decoded sums\n"
+      "  1: encoded sums\n"
+      "  2: high peak values\n"
+      "Which do you choose?",
+      choice);
   if (choice < 0 or choice > 2) {
-    PFEXCEPTION_RAISE("BadChoice", "Chosen fill value is not one of the options");
+    PFEXCEPTION_RAISE("BadChoice",
+                      "Chosen fill value is not one of the options");
   }
   return FWHistoPool::FillValue(choice);
 }
@@ -45,8 +47,8 @@ void histo(const std::string& cmd, Target* tgt) {
     static int ihist = 0;
     ihist = pftool::readline_int("Which histogram?", ihist);
     auto hist = hist_pool.read(prompt_fill_value(), ihist);
-    pflib_log(info) << "accumulated histogram for "
-                    << hist.collection_time() << "s";
+    pflib_log(info) << "accumulated histogram for " << hist.collection_time()
+                    << "s";
     bool raw_counts = true;
     if (hist.collection_time() > 0) {
       raw_counts =
@@ -75,8 +77,8 @@ void histo(const std::string& cmd, Target* tgt) {
 
   if (cmd == "DUMP") {
     auto hist = hist_pool.read(prompt_fill_value());
-    pflib_log(info) << "accumulated histograms for "
-                    << hist.collection_time() << "s";
+    pflib_log(info) << "accumulated histograms for " << hist.collection_time()
+                    << "s";
 
     if (pftool::readline_bool("Show histograms in terminal?", true)) {
       bool raw_counts = true;

--- a/app/tool/trig/trig.cxx
+++ b/app/tool/trig/trig.cxx
@@ -8,8 +8,8 @@
 #include "align.h"
 #include "decode_multi_sample.h"
 #include "histo.h"
-#include "pflib/packing/SingleECONTCaptureFrame.h"
 #include "pflib/packing/DecompressAEBM.h"
+#include "pflib/packing/SingleECONTCaptureFrame.h"
 #include "pflib/zcu/zcu_trig.h"
 #include "self_trig.h"
 #include "timein.h"
@@ -132,22 +132,28 @@ void ztrig(const std::string& cmd, Target* tgt) {
 
   static uint32_t decoder_lut_addr = 0;
   if (cmd == "DECODER_LUT_READ") {
-    decoder_lut_addr = pftool::readline_int("Encoded Value to Read: ", decoder_lut_addr, true);
+    decoder_lut_addr =
+        pftool::readline_int("Encoded Value to Read: ", decoder_lut_addr, true);
     uint32_t val = trig->get_decoder_lut(decoder_lut_addr);
     printf("0x%03x : %d\n", decoder_lut_addr, val);
   }
 
   if (cmd == "DECODER_LUT_WRITE") {
-    decoder_lut_addr = pftool::readline_int("Encoded Value to Write for: ", decoder_lut_addr, true);
-    uint32_t val = pftool::readline_int("Value to write: ", trig->get_decoder_lut(decoder_lut_addr));
+    decoder_lut_addr = pftool::readline_int(
+        "Encoded Value to Write for: ", decoder_lut_addr, true);
+    uint32_t val = pftool::readline_int(
+        "Value to write: ", trig->get_decoder_lut(decoder_lut_addr));
     trig->set_decoder_lut(decoder_lut_addr, val);
   }
 
   if (cmd == "DECODER_LUT_INIT") {
-    int divisor = pftool::readline_int("Scale to divide decoded values by: ", 1);
-    bool show_lut = pftool::readline_bool("Show LUT that is being written? ", true);
+    int divisor =
+        pftool::readline_int("Scale to divide decoded values by: ", 1);
+    bool show_lut =
+        pftool::readline_bool("Show LUT that is being written? ", true);
     for (int encoded_val{0}; encoded_val < (1 << 9); encoded_val++) {
-      unsigned long full_decoded_val = pflib::packing::decompressAEBM<5, 4>(encoded_val) / divisor;
+      unsigned long full_decoded_val =
+          pflib::packing::decompressAEBM<5, 4>(encoded_val) / divisor;
       // the LUT only has an output width of 16 bits, so we saturate
       // if the full decoded val (after dividing out the scale) would
       // be above this limit
@@ -201,7 +207,8 @@ auto menu_trig =
         ->line("ELINK_SPY", "spy on the six TRIG elinks", trig)
         ->line("EVENT_SPY", "attempt to read the last captured event", trig)
         ->line("DECODER_LUT_READ", "read a value from the decoding LUT", ztrig)
-        ->line("DECODER_LUT_WRITE", "write a value from the decoding LUT", ztrig)
+        ->line("DECODER_LUT_WRITE", "write a value from the decoding LUT",
+               ztrig)
         ->line("DECODER_LUT_INIT", "initialize the entire decoding LUT", ztrig);
 
 auto menu_expert =

--- a/app/tool/trig/trig.cxx
+++ b/app/tool/trig/trig.cxx
@@ -9,6 +9,8 @@
 #include "decode_multi_sample.h"
 #include "histo.h"
 #include "pflib/packing/SingleECONTCaptureFrame.h"
+#include "pflib/packing/DecompressAEBM.h"
+#include "pflib/zcu/zcu_trig.h"
 #include "self_trig.h"
 #include "timein.h"
 #include "watch_run.h"
@@ -122,6 +124,42 @@ void trig(const std::string& cmd, Target* target) {
 }
 
 /**
+ * ZCU trigger-specific stuff
+ */
+void ztrig(const std::string& cmd, Target* tgt) {
+  pflib::zcu::ZCUtrig* trig = dynamic_cast<pflib::zcu::ZCUtrig*>(tgt->trig());
+  if (!trig) return;
+
+  static uint32_t decoder_lut_addr = 0;
+  if (cmd == "DECODER_LUT_READ") {
+    decoder_lut_addr = pftool::readline_int("Encoded Value to Read: ", decoder_lut_addr, true);
+    uint32_t val = trig->get_decoder_lut(decoder_lut_addr);
+    printf("0x%03x : %d\n", decoder_lut_addr, val);
+  }
+
+  if (cmd == "DECODER_LUT_WRITE") {
+    decoder_lut_addr = pftool::readline_int("Encoded Value to Write for: ", decoder_lut_addr, true);
+    uint32_t val = pftool::readline_int("Value to write: ", trig->get_decoder_lut(decoder_lut_addr));
+    trig->set_decoder_lut(decoder_lut_addr, val);
+  }
+
+  if (cmd == "DECODER_LUT_INIT") {
+    int divisor = pftool::readline_int("Scale to divide decoded values by: ", 1);
+    for (int encoded_val{0}; encoded_val < (1 << 9); encoded_val++) {
+      unsigned long full_decoded_val = pflib::packing::decompressAEBM<5, 4>(encoded_val) / divisor;
+      // the LUT only has an output width of 16 bits, so we saturate
+      // if the full decoded val (after dividing out the scale) would
+      // be above this limit
+      uint32_t lut_decoded_val = 0xffff;
+      if (full_decoded_val < (1 << 16)) {
+        lut_decoded_val = static_cast<uint32_t>(full_decoded_val);
+      }
+      trig->set_decoder_lut(encoded_val, lut_decoded_val);
+    }
+  }
+}
+
+/**
  * TRIG.SETUP
  *
  * apply the various time offset parameters that were deduced in TIMEIN
@@ -159,7 +197,10 @@ auto menu_trig =
             setup)
         ->line("WATCH_RUN", "collect data following self-trigger", watch_run)
         ->line("ELINK_SPY", "spy on the six TRIG elinks", trig)
-        ->line("EVENT_SPY", "attempt to read the last captured event", trig);
+        ->line("EVENT_SPY", "attempt to read the last captured event", trig)
+        ->line("DECODER_LUT_READ", "read a value from the decoding LUT", ztrig)
+        ->line("DECODER_LUT_WRITE", "write a value from the decoding LUT", ztrig)
+        ->line("DECODER_LUT_INIT", "initialize the entire decoding LUT", ztrig);
 
 auto menu_expert =
     menu_trig->submenu("EXPERT", "low-level commands for debugging behavior")

--- a/app/tool/trig/trig.cxx
+++ b/app/tool/trig/trig.cxx
@@ -145,6 +145,7 @@ void ztrig(const std::string& cmd, Target* tgt) {
 
   if (cmd == "DECODER_LUT_INIT") {
     int divisor = pftool::readline_int("Scale to divide decoded values by: ", 1);
+    bool show_lut = pftool::readline_bool("Show LUT that is being written? ", true);
     for (int encoded_val{0}; encoded_val < (1 << 9); encoded_val++) {
       unsigned long full_decoded_val = pflib::packing::decompressAEBM<5, 4>(encoded_val) / divisor;
       // the LUT only has an output width of 16 bits, so we saturate
@@ -154,6 +155,7 @@ void ztrig(const std::string& cmd, Target* tgt) {
       if (full_decoded_val < (1 << 16)) {
         lut_decoded_val = static_cast<uint32_t>(full_decoded_val);
       }
+      if (show_lut) printf("0x%03x : %d\n", encoded_val, lut_decoded_val);
       trig->set_decoder_lut(encoded_val, lut_decoded_val);
     }
   }

--- a/include/pflib/zcu/zcu_trig.h
+++ b/include/pflib/zcu/zcu_trig.h
@@ -34,6 +34,9 @@ class ZCUtrig : public TRIG {
   bool is_sample_available() override;
   std::vector<uint32_t> read_sample() override;
 
+  uint32_t get_decoder_lut(uint32_t addr);
+  void set_decoder_lut(uint32_t addr, uint32_t val);
+
   void setup_algo(const std::vector<uint32_t>& parameters) override;
   std::vector<uint32_t> get_algo_setup() override;
   bool is_algo_output_available() override;

--- a/src/pflib/zcu/zcu_trig.cxx
+++ b/src/pflib/zcu/zcu_trig.cxx
@@ -135,6 +135,28 @@ std::vector<uint32_t> ZCUtrig::read_sample() {
   return retval;
 }
 
+static constexpr uint32_t ADDR_DECODER_LUT_READ = 0xC0C / 4;
+static constexpr uint32_t MASK_DECODER_LUT_READ = 0x0000ffff;
+
+static constexpr uint32_t ADDR_DECODER_LUT_CONF = 0x610 / 4;
+static constexpr uint32_t MASK_DECODER_LUT_WVAL = 0x0000ffff;
+static constexpr uint32_t MASK_DECODER_LUT_ADDR = 0x01ff0000;
+// the DO_WRITE strobe is in the ADDR_RESET register
+static constexpr uint32_t MASK_DECODER_LUT_DO_WRITE = 0x00000004;
+
+uint32_t ZCUtrig::get_decoder_lut(uint32_t addr) {
+  uio_.writeMasked(ADDR_DECODER_LUT_CONF, MASK_DECODER_LUT_ADDR, addr);
+  usleep(10);
+  return uio_.readMasked(ADDR_DECODER_LUT_READ, MASK_DECODER_LUT_READ);
+}
+
+void ZCUtrig::set_decoder_lut(uint32_t addr, uint32_t val) {
+  uio_.writeMasked(ADDR_DECODER_LUT_CONF, MASK_DECODER_LUT_ADDR, addr);
+  uio_.writeMasked(ADDR_DECODER_LUT_CONF, MASK_DECODER_LUT_WVAL, val);
+  usleep(10);
+  uio_.writeMasked(ADDR_RESET, MASK_DECODER_LUT_DO_WRITE, 1);
+}
+
 static constexpr uint32_t ADDR_HISTORY_VETO_MASK = 0x608 / 4;
 static constexpr uint32_t ADDR_THRESHOLDS = 0x60C / 4;
 

--- a/src/pflib/zcu/zcu_trig.cxx
+++ b/src/pflib/zcu/zcu_trig.cxx
@@ -138,23 +138,15 @@ std::vector<uint32_t> ZCUtrig::read_sample() {
 static constexpr uint32_t ADDR_DECODER_LUT_READ = 0xC0C / 4;
 static constexpr uint32_t MASK_DECODER_LUT_READ = 0x0000ffff;
 
-static constexpr uint32_t ADDR_DECODER_LUT_CONF = 0x620 / 4;
+static constexpr uint32_t ADDR_DECODER_LUT_CONF = 0x61C / 4;
 static constexpr uint32_t MASK_DECODER_LUT_WVAL = 0x0000ffff;
 static constexpr uint32_t MASK_DECODER_LUT_ADDR = 0x01ff0000;
 // the DO_WRITE strobe is in the ADDR_RESET register
-static constexpr uint32_t MASK_DECODER_LUT_DO_WRITE = 0x00000004;
+static constexpr uint32_t MASK_DECODER_LUT_DO_WRITE = 0x00000008;
 
 uint32_t ZCUtrig::get_decoder_lut(uint32_t addr) {
   uio_.writeMasked(ADDR_DECODER_LUT_CONF, MASK_DECODER_LUT_ADDR, addr);
-  usleep(100);
-  for (int i{0}; i < 32; i++) {
-    uint32_t addr = 0xC00 / 4 + i;
-    printf("0x%03x : %08x\n", addr*4, uio_.read(addr));
-  }
-  for (int i{0}; i < 32; i++) {
-    uint32_t addr = 0x600 / 4 + i;
-    printf("0x%03x : %08x\n", addr*4, uio_.read(addr));
-  }
+  usleep(10);
   return uio_.readMasked(ADDR_DECODER_LUT_READ, MASK_DECODER_LUT_READ);
 }
 

--- a/src/pflib/zcu/zcu_trig.cxx
+++ b/src/pflib/zcu/zcu_trig.cxx
@@ -138,7 +138,7 @@ std::vector<uint32_t> ZCUtrig::read_sample() {
 static constexpr uint32_t ADDR_DECODER_LUT_READ = 0xC0C / 4;
 static constexpr uint32_t MASK_DECODER_LUT_READ = 0x0000ffff;
 
-static constexpr uint32_t ADDR_DECODER_LUT_CONF = 0x610 / 4;
+static constexpr uint32_t ADDR_DECODER_LUT_CONF = 0x620 / 4;
 static constexpr uint32_t MASK_DECODER_LUT_WVAL = 0x0000ffff;
 static constexpr uint32_t MASK_DECODER_LUT_ADDR = 0x01ff0000;
 // the DO_WRITE strobe is in the ADDR_RESET register
@@ -146,7 +146,15 @@ static constexpr uint32_t MASK_DECODER_LUT_DO_WRITE = 0x00000004;
 
 uint32_t ZCUtrig::get_decoder_lut(uint32_t addr) {
   uio_.writeMasked(ADDR_DECODER_LUT_CONF, MASK_DECODER_LUT_ADDR, addr);
-  usleep(10);
+  usleep(100);
+  for (int i{0}; i < 32; i++) {
+    uint32_t addr = 0xC00 / 4 + i;
+    printf("0x%03x : %08x\n", addr*4, uio_.read(addr));
+  }
+  for (int i{0}; i < 32; i++) {
+    uint32_t addr = 0x600 / 4 + i;
+    printf("0x%03x : %08x\n", addr*4, uio_.read(addr));
+  }
   return uio_.readMasked(ADDR_DECODER_LUT_READ, MASK_DECODER_LUT_READ);
 }
 


### PR DESCRIPTION
In parallel with firmware development, this code gives access to updating the decoder LUT, histograms for the decoded STC sums and high-peak, 3-BX-rolling-sum value that is used to make the trigger decision.

The decoder lut, updated trigger algorithm, and extra firmware histograms are included in the latest zcu firmware `20260807_141018-9f7b783e`. Since summing across BX has been included in the trigger algorithm, the timing parameters need to be increased by one or two in order for the pulse to be faithfully captured. I will update the wiki notes while confirming this all works.