### PR TITLE
Single photon Spectrum event

### DIFF
--- a/ana/LED/SPS_histogram.py
+++ b/ana/LED/SPS_histogram.py
@@ -1,3 +1,4 @@
+<<<<<<< Updated upstream
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -59,3 +60,96 @@ for channel, ch_df in channel_groups:
         output_name = (f'channel_{channel}_trim_inv_{trim_inv}_SiPM_DAC_{SiPM_DAC}_LED_DAC_{LED_DAC}.png')
         plt.savefig(output_dir / output_name, dpi=300)
         plt.close()
+=======
+import pandas as pd
+import matplotlib.pyplot as plt
+import numpy as np
+
+def analyze_and_plot_sps(csv_file_path="SPS-scan.csv"):
+    print(f"Loading data from: {csv_file_path}")
+
+    df = pd.read_csv(csv_file_path, comment='#')
+    df.columns = df.columns.str.strip()
+
+    adc_col = [col for col in df.columns if col.lower() == 'adc'][0]
+
+    # Reconstruct event IDs if not explicitly present
+    event_cols = [c for c in df.columns if c.lower() in ['event', 'evt', 'event_id']]
+    if event_cols:
+        evt_col = event_cols[0]
+    else:
+        evt_col = 'event_id'
+        df[evt_col] = (df['sample'] == 0).groupby([df['ch'], df['trim_inv'], df['phase_ck']]).cumsum()
+
+    # --- STEP 1: DNL CORRECTION PER TRIM_INV SETTING ---
+    # Determine base TRIM_INV and calculate shift delta: 0, 1, or 2
+    base_trim = df['trim_inv'].min()
+    df['delta_trim'] = df['trim_inv'] - base_trim
+
+    # Subtract 1 ADC tic per trim_inv step from each raw BX sample
+    df['adc_dnl_corrected'] = df[adc_col] - df['delta_trim']
+
+    print(f"Step 1: Applied DNL baseline shift corrections (base TRIM_INV = {base_trim})...")
+
+    # --- STEP 2: SUM ACROSS 3 BXs PER EVENT ---
+    summed_3bx = (
+        df.groupby([evt_col, 'ch', 'trim_inv', 'phase_ck'], as_index=False)['adc_dnl_corrected']
+        .sum()
+        .rename(columns={'adc_dnl_corrected': 'adc_3bx_dnl_corrected'})
+    )
+
+    # --- STEP 3: AVERAGE ACROSS THE THREE TRIM_INV SETTINGS ---
+    print("Step 2: Combining and averaging across TRIM_INV settings...")
+    avg_trim = (
+        summed_3bx.groupby([evt_col, 'ch', 'phase_ck'], as_index=False)['adc_3bx_dnl_corrected']
+        .mean()
+        .rename(columns={'adc_3bx_dnl_corrected': 'averaged_adc_sum'})
+    )
+
+    # --- PLOTTING ---
+    fig, axes = plt.subplots(1, 2, figsize=(15, 6))
+
+    # Plot 1: Pulse Timing Scan (Phase curve)
+    for ch, ch_data in avg_trim.groupby('ch'):
+        phase_stats = ch_data.groupby('phase_ck')['averaged_adc_sum'].agg(['mean', 'std', 'count'])
+        phase_stats['sem'] = phase_stats['std'] / np.sqrt(phase_stats['count'])
+
+        axes[0].errorbar(
+            phase_stats.index,
+            phase_stats['mean'],
+            yerr=phase_stats['sem'],
+            fmt='-o',
+            capsize=4,
+            label=f'Channel {ch}'
+        )
+
+    axes[0].set_title("DNL-Corrected Phase Scan\n(3-BX Sum vs. PHASE_CK)", fontsize=12)
+    axes[0].set_xlabel("PHASE_CK", fontsize=11)
+    axes[0].set_ylabel("DNL-Corrected 3-BX Summed ADC", fontsize=11)
+    axes[0].grid(True, linestyle="--", alpha=0.6)
+    axes[0].legend()
+
+    # Plot 2: Histogram of DNL-Smoothed Signal Amplitudes
+    for ch, ch_data in avg_trim.groupby('ch'):
+        axes[1].hist(
+            ch_data['averaged_adc_sum'],
+            bins=100,
+            alpha=0.6,
+            label=f'Channel {ch}',
+            edgecolor='black',
+            linewidth=0.5
+        )
+
+    axes[1].set_title("SPS Histogram (DNL Corrected)", fontsize=12)
+    axes[1].set_xlabel("Amplitude (DNL-Corrected 3-BX Summed ADC)", fontsize=11)
+    axes[1].set_ylabel("Counts", fontsize=11)
+    axes[1].grid(True, linestyle="--", alpha=0.6)
+    axes[1].legend()
+
+    plt.tight_layout()
+    plt.savefig("sps_readout_dnl_corrected.png", dpi=300)
+    plt.show()
+
+if __name__ == "__main__":
+    analyze_and_plot_sps("SPS-scan.csv")
+>>>>>>> Stashed changes

--- a/ana/LED/SPS_histogram.py
+++ b/ana/LED/SPS_histogram.py
@@ -1,0 +1,61 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import pandas as pd
+import numpy as np
+import mplhep as hep
+from pathlib import Path
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('dataset', type=Path, help='LED bias scan file path')
+args = parser.parse_args()
+
+data_dir = args.dataset.parent
+output_dir = data_dir / f"{args.dataset.stem}_SPS_graphs"
+output_dir.mkdir(exist_ok = True)
+
+df = pd.read_csv(args.dataset, comment='#', skipinitialspace=True)
+
+channel_groups = df.groupby('ch')
+
+for channel, ch_df in channel_groups:
+
+    # group by trim_inv
+    trim_inv_groups = ch_df.groupby('trim_inv')
+
+    for trim_inv, trim_df in trim_inv_groups:
+
+        phase_ck_groups = trim_df.groupby('phase_ck')
+
+        fig, ax = plt.subplots(figsize=(8, 5))
+
+        data_hist = []
+        labels = []
+
+        for phase_ck, phase_df in phase_ck_groups:
+
+          data_hist.append(phase_df["adc"])
+          SiPM_DAC = phase_df["SiPM_DAC"].iloc[10]
+          LED_DAC = phase_df["LED_DAC"].iloc[10]
+          labels.append(f"phase_ck = {phase_ck}")
+
+        max_adc = int(np.max(data_hist))
+        min_adc = int(np.min(data_hist))
+        bins = np.arange(min_adc - 0.5, max_adc + 1.5, 1)
+
+        counts, edges = np.histogram(data_hist, bins)
+        errors = np.sqrt(counts)
+        centers = (edges[:-1] + edges[1:]) / 2
+        hep.histplot((counts, edges), ax=ax, histtype='step', density=False, label=labels)
+        ax.errorbar(centers, counts, yerr=errors, fmt='.', capsize=2, markersize=3)
+        ax.set_xlabel('ADC value')
+        ax.set_ylabel('Count Per Bin')
+        ax.set_title(f'Single Photon Spectrum\n HGCROC Channel =  {channel}, TRIM_INV = {trim_inv}, SiPM_DAC = {SiPM_DAC}, LED_DAC = {LED_DAC}')
+        ax.grid(False)
+        ax.legend(bbox_to_anchor=(1.05, 1), loc='upper left', fontsize=7)
+        plt.tight_layout()
+           #ax.xaxis.set_major_locator(plt.MultipleLocator(1))
+
+        output_name = (f'channel_{channel}_trim_inv_{trim_inv}_SiPM_DAC_{SiPM_DAC}_LED_DAC_{LED_DAC}.png')
+        plt.savefig(output_dir / output_name, dpi=300)
+        plt.close()

--- a/app/tool/tasks/SPS_readout.cxx
+++ b/app/tool/tasks/SPS_readout.cxx
@@ -7,23 +7,38 @@
 #include "../pftool.h"
 #include "pflib/Bias.h"
 #include "pflib/HcalTarget.h"
+<<<<<<< Updated upstream
 #include "pflib/TRIG.h"
 #include "pflib/packing/Hex.h"
+=======
+>>>>>>> Stashed changes
 #include "pflib/utility/string_format.h"
 
 ENABLE_LOGGING();
 
 void sps_readout(Target* tgt) {
+<<<<<<< Updated upstream
   int cmb_to_ch[16][4] = {
+=======
+
+ int cmb_to_ch[16][4] = {
+>>>>>>> Stashed changes
       {0, 1, 2, 3},     {4, 5, 6, 7},     {9, 10, 11, 12},  {13, 14, 15, 16},
       {18, 19, 20, 21}, {22, 23, 24, 25}, {27, 28, 29, 30}, {31, 32, 33, 34},
       {36, 37, 38, 39}, {40, 41, 42, 43}, {45, 46, 47, 48}, {49, 50, 51, 52},
       {54, 55, 56, 57}, {58, 59, 60, 61}, {63, 64, 65, 66}, {67, 68, 69, 70}};
 
+<<<<<<< Updated upstream
   tgt->setup_run(1, Target::DaqFormat::ECOND_SW_HEADERS, 1);
   pflib::DAQ& daq = tgt->daq();
 
   auto hcalbp = dynamic_cast<pflib::HcalTarget*>(tgt);
+=======
+// 3 time samples per event
+tgt->setup_run(3, Target::DaqFormat::ECOND_SW_HEADERS, 1);
+
+auto hcalbp = dynamic_cast<pflib::HcalTarget*>(tgt);
+>>>>>>> Stashed changes
   if (!hcalbp) {
     PFEXCEPTION_RAISE("BadTarget",
                       "led_bias_scan only available for Hcal targets");
@@ -35,6 +50,7 @@ void sps_readout(Target* tgt) {
   auto& bias = hcalbp->bias(iboard);
   auto& mapping{tgt->getRocErxMapping()};
 
+<<<<<<< Updated upstream
   int cmb_port = pftool::readline_int("Channel to scan on? ", 0);
   int nevents = pftool::readline_int("How many events per time point? ", 1000);
   int start_led = tgt->fc().fc_get_setup_led();
@@ -59,6 +75,27 @@ void sps_readout(Target* tgt) {
 
   bias.setSiPM(cmb_port, new_SiPM);
   bias.setLED(cmb_port, new_LED);
+=======
+int cmb_port = pftool::readline_int("Channel to scan on? ", 0);
+int nevents = pftool::readline_int("How many events per time point? ", 1000);
+int tgt_bx = pftool::readline_int("Target BX? ", 22);
+int start_led = tgt->fc().fc_get_setup_led();
+//int start_led_new = pftool::readline_int("Calibration L1A offset for LED start point", start_led);
+int n_links = 2 * tgt->nrocs();
+
+int start_SiPM = bias.readSiPM(cmb_port).value_or(-1);
+int start_LED = bias.readLED(cmb_port).value_or(-1);
+int new_SiPM = pftool::readline_int("SiPM DAC value? ", start_SiPM);
+int new_LED = pftool::readline_int("LED DAC value? ", start_LED);
+
+int start_phase_ck = pftool::readline_int("Starting PHASE_CK value? ", 0);
+int end_phase_ck = pftool::readline_int("Ending PHASE_CK value? ", 0);
+int trim_inv = pftool::readline_int("TRIM_INV value? ", 2);
+int trim_range = pftool::readline_int("Range of TRIM_INV values to scan over for convolution? ", 1);
+
+bias.setSiPM(cmb_port, new_SiPM);
+bias.setLED(cmb_port, new_LED);
+>>>>>>> Stashed changes
 
   pflib::ROC roc{tgt->roc(iboard)};
 
@@ -66,6 +103,7 @@ void sps_readout(Target* tgt) {
   auto test_param_builder = roc.testParameters();
   fname = pftool::readline_path("SPS-scan", ".csv");
 
+<<<<<<< Updated upstream
   int g = 0;
   int phase_ck = 0;
 
@@ -75,6 +113,23 @@ void sps_readout(Target* tgt) {
         nlohmann::ordered_json header;
         f << std::boolalpha << "# " << header << '\n'
           << "i_cmb_port,ch,trim_inv,phase_ck,SiPM_DAC,LED_DAC,"
+=======
+int g = 0;
+int phase_ck = 0;
+
+ DecodeAndWriteToCSV writer{
+      fname,
+      [&](std::ofstream& f) {
+        nlohmann::ordered_json header;
+        //header["Min CMB port"] = min_cmb_port;
+        //header["Max CMB port"] = max_cmb_port;
+        //header["LED DAC start"] = LEDstart;
+        //header["LED DAC end"] = LEDend;
+        //header["SiPM DAC start"] = SiPMstart;
+        //header["SiPM DAC end"] = SiPMend;
+        f << std::boolalpha << "# " << header << '\n'
+          << "i_cmb_port,ch,trim_inv,phase_ck,"
+>>>>>>> Stashed changes
           << pflib::packing::Sample::to_csv_header << '\n';
       },
       [&](std::ofstream& f,
@@ -82,14 +137,23 @@ void sps_readout(Target* tgt) {
         for (int j = 0; j < 4; j++) {
           auto ch = cmb_to_ch[cmb_port][j];
           auto [i_erx, i_ch] = mapping.toErxChannel(iboard, ch);
+<<<<<<< Updated upstream
           f << cmb_port << ',' << i_ch << ',' << g << ',' << phase_ck << ','
             << new_SiPM << ',' << new_LED << ',';
           ep.samples[ep.i_soi].channel(i_erx, i_ch).to_csv(f);
           f << '\n';
+=======
+          for (std::size_t sample = 0; sample < ep.samples.size(); ++sample) {
+            f << cmb_port << ',' << i_ch << ',' << g << ',' << phase_ck << ',' ;
+            ep.samples[sample].channel(i_erx, i_ch).to_csv(f);
+            f << '\n';
+          }
+>>>>>>> Stashed changes
         }
       },
       n_links};
 
+<<<<<<< Updated upstream
   // Makes sure charge injections are turned on for this individual channel
   for (int j = 0; j < 4; j++) {
     auto ch = cmb_to_ch[cmb_port][j];
@@ -118,10 +182,39 @@ void sps_readout(Target* tgt) {
       test_param_builder.add(cm_page, "GAIN_CONV", 7);  // 0 to 7
     }
     test_param_builder.add(channel_page, "GAIN_CONV", 7);  // 0 to 7
+=======
+// Makes sure charge injections are turned on for this individual channel
+for (int j = 0; j < 4; j++) {
+  auto ch = cmb_to_ch[cmb_port][j];
+  int link = (ch / 36);
+  auto channel_page = pflib::utility::string_format("CH_%d", ch);
+  auto refvol_page = pflib::utility::string_format("REFERENCEVOLTAGE_%d", link);
+  auto calib_page = pflib::utility::string_format("CALIB_%d", link);
+  auto global_page = pflib::utility::string_format("GLOBALANALOG_%d", link);
+  test_param_builder.add(refvol_page, "CALIB", 0)
+    .add(refvol_page, "CALIB_2V5", 0)
+    .add(refvol_page, "INTCTEST", 1)
+    .add(refvol_page, "CHOICE_CINJ", 0)
+    .add(global_page, "CD", 2)
+    .add(global_page, "CF", 8)
+    .add(global_page, "RF", 10)
+    .add(channel_page, "HIGHRANGE", 0)
+    .add(channel_page, "LOWRANGE", 0)
+    .add(calib_page, "INPUTDAC", 0) //No idea what this should be
+    .add(channel_page, "INPUTDAC", 0) //No idea what this should be
+    .add(global_page, "GAIN_CONV", 1) //0 or 1
+    .add(calib_page, "GAIN_CONV", 4); //0 or 1
+    for (int k = 0; k < 4; k++){
+      auto cm_page = pflib::utility::string_format("CM_%d", link);
+       test_param_builder.add(cm_page, "GAIN_CONV", 4); //0 to 7
+    }
+    test_param_builder.add(channel_page, "GAIN_CONV", 4); //0 to 7
+>>>>>>> Stashed changes
   }
 
   auto test_param_handle = test_param_builder.apply();
 
+<<<<<<< Updated upstream
   for (g = (trim_inv - trim_range); g < (trim_inv + trim_range + 1); g++) {
     pflib_log(info) << "TRIM_INV set to = " << g;
 
@@ -161,3 +254,35 @@ void sps_readout(Target* tgt) {
   }
 
 }  // sps_readout
+=======
+int base_trim_inv = pftool::readline_int("Base TRIM_INV value? ", 2);
+
+for (g = base_trim_inv; g <= base_trim_inv + 2; g++){
+
+  pflib_log(info) << "TRIM_INV set to = " << g << " (offset +" << (g - base_trim_inv) << ")";
+
+  std::map<std::string, std::map<std::string, uint64_t>> page_stat;
+
+  for (int j = 0; j < 4; j++) {
+    auto ch = cmb_to_ch[cmb_port][j];
+    auto ch_str = pflib::utility::string_format("CH_%d", ch);
+    page_stat[ch_str]["TRIM_INV"] = g;
+  }
+  auto trim_inv_apply =  tgt->tempApplyAllROCs(page_stat);
+
+  for (phase_ck = start_phase_ck; phase_ck <= end_phase_ck; phase_ck++){
+    pflib_log(info) << "PHASE_CK = " << phase_ck;
+
+    auto phase_test_handle = roc.testParameters().add("TOP", "PHASE_CK", phase_ck).apply();
+
+    //tgt->fc().fc_setup_led(start_led_new);
+    tgt->fc().fc_setup_led(tgt_bx);
+    pflib_log(info) << " Target BX  = " << tgt_bx <<"\n";
+
+    daq_run(tgt, "LED", writer, nevents, pftool::state.daq_rate);
+    usleep(10);
+    }
+  }
+
+} //sps_readout
+>>>>>>> Stashed changes

--- a/app/tool/tasks/SPS_readout.cxx
+++ b/app/tool/tasks/SPS_readout.cxx
@@ -1,0 +1,160 @@
+#include "SPS_readout.h"
+
+#include <filesystem>
+#include <nlohmann/json.hpp>
+
+#include "pflib/TRIG.h"
+#include "pflib/packing/Hex.h"
+#include "../daq_run.h"
+#include "../pftool.h"
+#include "pflib/Bias.h"
+#include "pflib/HcalTarget.h"
+#include "pflib/utility/string_format.h"
+
+ENABLE_LOGGING();
+
+void sps_readout(Target* tgt) {
+
+ int cmb_to_ch[16][4] = {
+      {0, 1, 2, 3},     {4, 5, 6, 7},     {9, 10, 11, 12},  {13, 14, 15, 16},
+      {18, 19, 20, 21}, {22, 23, 24, 25}, {27, 28, 29, 30}, {31, 32, 33, 34},
+      {36, 37, 38, 39}, {40, 41, 42, 43}, {45, 46, 47, 48}, {49, 50, 51, 52},
+      {54, 55, 56, 57}, {58, 59, 60, 61}, {63, 64, 65, 66}, {67, 68, 69, 70}};
+
+tgt->setup_run(1, Target::DaqFormat::ECOND_SW_HEADERS, 1);
+pflib::DAQ& daq = tgt->daq();
+
+auto hcalbp = dynamic_cast<pflib::HcalTarget*>(tgt);
+  if (!hcalbp) {
+    PFEXCEPTION_RAISE("BadTarget",
+                      "led_bias_scan only available for Hcal targets");
+  }
+
+  int iboard = 1;
+  iboard = pftool::readline_int("Which board? ", iboard);
+  // static void bias(const std::string& cmd, pflib::HcalTarget* pft){
+  auto& bias = hcalbp->bias(iboard);
+  auto& mapping{tgt->getRocErxMapping()};
+
+int cmb_port = pftool::readline_int("Channel to scan on? ", 0);
+int nevents = pftool::readline_int("How many events per time point? ", 1000);
+int start_led = tgt->fc().fc_get_setup_led();
+int tgt_bx = pftool::readline_int("Target BX? (~22 should be BX = 4) ", start_led);
+int len_bx = pftool::readline_int("Number of BX to scan over? ", 2);
+tgt->fc().setL1AperROR(len_bx);
+//int start_led_new = pftool::readline_int("Calibration L1A offset for LED start point", start_led);
+int n_links = 2 * tgt->nrocs();
+
+int start_SiPM = bias.readSiPM(cmb_port).value_or(-1);
+int start_LED = bias.readLED(cmb_port).value_or(-1);
+int new_SiPM = pftool::readline_int("SiPM DAC value? ", start_SiPM);
+int new_LED = pftool::readline_int("LED DAC value? ", start_LED);
+
+int start_phase_ck = pftool::readline_int("Starting PHASE_CK value? ", 2);
+int end_phase_ck = pftool::readline_int("Ending PHASE_CK value? ", 2);
+int trim_inv = pftool::readline_int("TRIM_INV value? ", 2);
+int trim_range = pftool::readline_int("Range of TRIM_INV values to scan over for convolution? ", 1);
+
+bias.setSiPM(cmb_port, new_SiPM);
+bias.setLED(cmb_port, new_LED);
+
+  pflib::ROC roc{tgt->roc(iboard)};
+
+  std::string fname;
+  auto test_param_builder = roc.testParameters();
+  fname = pftool::readline_path("SPS-scan", ".csv");
+
+int g = 0;
+int phase_ck = 0;
+
+ DecodeAndWriteToCSV writer{
+      fname,
+      [&](std::ofstream& f) {
+        nlohmann::ordered_json header;
+        f << std::boolalpha << "# " << header << '\n'
+          << "i_cmb_port,ch,trim_inv,phase_ck,SiPM_DAC,LED_DAC,"
+          << pflib::packing::Sample::to_csv_header << '\n';
+      },
+      [&](std::ofstream& f,
+          const pflib::packing::MultiSampleECONDEventPacket& ep) {
+        for (int j = 0; j < 4; j++) {
+          auto ch = cmb_to_ch[cmb_port][j];
+          auto [i_erx, i_ch] = mapping.toErxChannel(iboard, ch);
+          f << cmb_port << ',' << i_ch << ',' << g << ',' << phase_ck << ','  << new_SiPM  << ','  << new_LED  << ',' ;
+          ep.samples[ep.i_soi].channel(i_erx, i_ch).to_csv(f);
+          f << '\n';
+        }
+      },
+      n_links};
+
+// Makes sure charge injections are turned on for this individual channel
+for (int j = 0; j < 4; j++) {
+  auto ch = cmb_to_ch[cmb_port][j];
+  int link = (ch / 36);
+  auto channel_page = pflib::utility::string_format("CH_%d", ch);
+  auto refvol_page = pflib::utility::string_format("REFERENCEVOLTAGE_%d", link);
+  auto calib_page = pflib::utility::string_format("CALIB_%d", link);
+  auto global_page = pflib::utility::string_format("GLOBALANALOG_%d", link);
+  test_param_builder.add(refvol_page, "CALIB", 0)
+    .add(refvol_page, "CALIB_2V5", 0)
+    .add(refvol_page, "INTCTEST", 1)
+    .add(refvol_page, "CHOICE_CINJ", 0)
+    .add(global_page, "CD", 2)
+    .add(global_page, "CF", 8)
+    .add(global_page, "RF", 10)
+    .add(channel_page, "HIGHRANGE", 0)
+    .add(channel_page, "LOWRANGE", 0)
+    .add(calib_page, "INPUTDAC", 32) //No idea what this should be (MAXES out at 63)
+    .add(channel_page, "INPUTDAC", 32) //No idea what this should be
+    .add(global_page, "GAIN_CONV", 1) //0 or 1
+    .add(calib_page, "GAIN_CONV", 7); //0 or 1
+    for (int k = 0; k < 4; k++){
+      auto cm_page = pflib::utility::string_format("CM_%d", link);
+       test_param_builder.add(cm_page, "GAIN_CONV", 7); //0 to 7
+    }
+    test_param_builder.add(channel_page, "GAIN_CONV", 7); //0 to 7
+  }
+
+  auto test_param_handle = test_param_builder.apply();
+
+
+for (g = (trim_inv - trim_range); g < (trim_inv + trim_range + 1); g++){
+
+  pflib_log(info) << "TRIM_INV set to = " << g;
+
+  std::map<std::string, std::map<std::string, uint64_t>> page_stat;
+
+  for (int j = 0; j < 4; j++) {
+    auto ch = cmb_to_ch[cmb_port][j];
+    auto ch_str = pflib::utility::string_format("CH_%d", ch);
+    page_stat[ch_str]["TRIM_INV"] = g;
+  }
+  auto trim_inv_apply =  tgt->tempApplyAllROCs(page_stat);
+
+  for (phase_ck = start_phase_ck; phase_ck <= end_phase_ck; phase_ck++){
+    pflib_log(info) << "PHASE_CK = " << phase_ck;
+
+    auto phase_test_handle = roc.testParameters().add("TOP", "PHASE_CK", phase_ck).apply();
+
+    bool enable_l1a_follow;
+    //int central_charge_to_l1a = tgt->fc().fc_get_setup_led();
+
+    //tgt->fc().fc_setup_led(start_led_new);
+    tgt->fc().fc_setup_led(tgt_bx);
+    pflib_log(info) << " Target BX  = " << tgt_bx <<"\n";
+
+    daq_run(tgt, "LED", writer, nevents, pftool::state.daq_rate);
+    usleep(10);
+    //auto data = buffer.get_buffer();
+    //auto mapping = tgt->getRocErxMapping();
+    //auto [i_erx, i_ch] = mapping.toErxChannel(i_roc, 17);
+    //for (std::size_t i{0}; i < data.size(); i++) {
+      //for (int j = 0; j < nr_bx; j++) {
+        //adcs[j].push_back(data[i].samples.at(j).channel(i_erx, i_ch).adc());
+      //}
+    //}
+
+    }
+  }
+
+} //sps_readout

--- a/app/tool/tasks/SPS_readout.cxx
+++ b/app/tool/tasks/SPS_readout.cxx
@@ -10,23 +10,35 @@
 <<<<<<< Updated upstream
 #include "pflib/TRIG.h"
 #include "pflib/packing/Hex.h"
-=======
+    =======
 >>>>>>> Stashed changes
 #include "pflib/utility/string_format.h"
 
-ENABLE_LOGGING();
+    ENABLE_LOGGING();
 
 void sps_readout(Target* tgt) {
 <<<<<<< Updated upstream
   int cmb_to_ch[16][4] = {
 =======
-
- int cmb_to_ch[16][4] = {
+  int cmb_to_ch[16][4] = {
 >>>>>>> Stashed changes
-      {0, 1, 2, 3},     {4, 5, 6, 7},     {9, 10, 11, 12},  {13, 14, 15, 16},
-      {18, 19, 20, 21}, {22, 23, 24, 25}, {27, 28, 29, 30}, {31, 32, 33, 34},
-      {36, 37, 38, 39}, {40, 41, 42, 43}, {45, 46, 47, 48}, {49, 50, 51, 52},
-      {54, 55, 56, 57}, {58, 59, 60, 61}, {63, 64, 65, 66}, {67, 68, 69, 70}};
+    {0, 1, 2, 3},
+    {4, 5, 6, 7},
+    {9, 10, 11, 12},
+    {13, 14, 15, 16},
+    {18, 19, 20, 21},
+    {22, 23, 24, 25},
+    {27, 28, 29, 30},
+    {31, 32, 33, 34},
+    {36, 37, 38, 39},
+    {40, 41, 42, 43},
+    {45, 46, 47, 48},
+    {49, 50, 51, 52},
+    {54, 55, 56, 57},
+    {58, 59, 60, 61},
+    {63, 64, 65, 66},
+    {67, 68, 69, 70}
+  };
 
 <<<<<<< Updated upstream
   tgt->setup_run(1, Target::DaqFormat::ECOND_SW_HEADERS, 1);
@@ -34,10 +46,10 @@ void sps_readout(Target* tgt) {
 
   auto hcalbp = dynamic_cast<pflib::HcalTarget*>(tgt);
 =======
-// 3 time samples per event
-tgt->setup_run(3, Target::DaqFormat::ECOND_SW_HEADERS, 1);
+  // 3 time samples per event
+  tgt->setup_run(3, Target::DaqFormat::ECOND_SW_HEADERS, 1);
 
-auto hcalbp = dynamic_cast<pflib::HcalTarget*>(tgt);
+  auto hcalbp = dynamic_cast<pflib::HcalTarget*>(tgt);
 >>>>>>> Stashed changes
   if (!hcalbp) {
     PFEXCEPTION_RAISE("BadTarget",
@@ -76,25 +88,27 @@ auto hcalbp = dynamic_cast<pflib::HcalTarget*>(tgt);
   bias.setSiPM(cmb_port, new_SiPM);
   bias.setLED(cmb_port, new_LED);
 =======
-int cmb_port = pftool::readline_int("Channel to scan on? ", 0);
-int nevents = pftool::readline_int("How many events per time point? ", 1000);
-int tgt_bx = pftool::readline_int("Target BX? ", 22);
-int start_led = tgt->fc().fc_get_setup_led();
-//int start_led_new = pftool::readline_int("Calibration L1A offset for LED start point", start_led);
-int n_links = 2 * tgt->nrocs();
+  int cmb_port = pftool::readline_int("Channel to scan on? ", 0);
+  int nevents = pftool::readline_int("How many events per time point? ", 1000);
+  int tgt_bx = pftool::readline_int("Target BX? ", 22);
+  int start_led = tgt->fc().fc_get_setup_led();
+  // int start_led_new = pftool::readline_int("Calibration L1A offset for LED
+  // start point", start_led);
+  int n_links = 2 * tgt->nrocs();
 
-int start_SiPM = bias.readSiPM(cmb_port).value_or(-1);
-int start_LED = bias.readLED(cmb_port).value_or(-1);
-int new_SiPM = pftool::readline_int("SiPM DAC value? ", start_SiPM);
-int new_LED = pftool::readline_int("LED DAC value? ", start_LED);
+  int start_SiPM = bias.readSiPM(cmb_port).value_or(-1);
+  int start_LED = bias.readLED(cmb_port).value_or(-1);
+  int new_SiPM = pftool::readline_int("SiPM DAC value? ", start_SiPM);
+  int new_LED = pftool::readline_int("LED DAC value? ", start_LED);
 
-int start_phase_ck = pftool::readline_int("Starting PHASE_CK value? ", 0);
-int end_phase_ck = pftool::readline_int("Ending PHASE_CK value? ", 0);
-int trim_inv = pftool::readline_int("TRIM_INV value? ", 2);
-int trim_range = pftool::readline_int("Range of TRIM_INV values to scan over for convolution? ", 1);
+  int start_phase_ck = pftool::readline_int("Starting PHASE_CK value? ", 0);
+  int end_phase_ck = pftool::readline_int("Ending PHASE_CK value? ", 0);
+  int trim_inv = pftool::readline_int("TRIM_INV value? ", 2);
+  int trim_range = pftool::readline_int(
+      "Range of TRIM_INV values to scan over for convolution? ", 1);
 
-bias.setSiPM(cmb_port, new_SiPM);
-bias.setLED(cmb_port, new_LED);
+  bias.setSiPM(cmb_port, new_SiPM);
+  bias.setLED(cmb_port, new_LED);
 >>>>>>> Stashed changes
 
   pflib::ROC roc{tgt->roc(iboard)};
@@ -107,17 +121,17 @@ bias.setLED(cmb_port, new_LED);
   int g = 0;
   int phase_ck = 0;
 
-  DecodeAndWriteToCSV writer{
-      fname,
-      [&](std::ofstream& f) {
-        nlohmann::ordered_json header;
-        f << std::boolalpha << "# " << header << '\n'
-          << "i_cmb_port,ch,trim_inv,phase_ck,SiPM_DAC,LED_DAC,"
+  DecodeAndWriteToCSV writer {
+    fname,
+        [&](std::ofstream& f) {
+          nlohmann::ordered_json header;
+          f << std::boolalpha << "# " << header << '\n'
+            << "i_cmb_port,ch,trim_inv,phase_ck,SiPM_DAC,LED_DAC,"
 =======
-int g = 0;
-int phase_ck = 0;
+  int g = 0;
+  int phase_ck = 0;
 
- DecodeAndWriteToCSV writer{
+  DecodeAndWriteToCSV writer{
       fname,
       [&](std::ofstream& f) {
         nlohmann::ordered_json header;
@@ -130,18 +144,18 @@ int phase_ck = 0;
         f << std::boolalpha << "# " << header << '\n'
           << "i_cmb_port,ch,trim_inv,phase_ck,"
 >>>>>>> Stashed changes
-          << pflib::packing::Sample::to_csv_header << '\n';
-      },
-      [&](std::ofstream& f,
-          const pflib::packing::MultiSampleECONDEventPacket& ep) {
-        for (int j = 0; j < 4; j++) {
-          auto ch = cmb_to_ch[cmb_port][j];
-          auto [i_erx, i_ch] = mapping.toErxChannel(iboard, ch);
+            << pflib::packing::Sample::to_csv_header << '\n';
+        },
+        [&](std::ofstream& f,
+            const pflib::packing::MultiSampleECONDEventPacket& ep) {
+          for (int j = 0; j < 4; j++) {
+            auto ch = cmb_to_ch[cmb_port][j];
+            auto [i_erx, i_ch] = mapping.toErxChannel(iboard, ch);
 <<<<<<< Updated upstream
-          f << cmb_port << ',' << i_ch << ',' << g << ',' << phase_ck << ','
-            << new_SiPM << ',' << new_LED << ',';
-          ep.samples[ep.i_soi].channel(i_erx, i_ch).to_csv(f);
-          f << '\n';
+            f << cmb_port << ',' << i_ch << ',' << g << ',' << phase_ck << ','
+              << new_SiPM << ',' << new_LED << ',';
+            ep.samples[ep.i_soi].channel(i_erx, i_ch).to_csv(f);
+            f << '\n';
 =======
           for (std::size_t sample = 0; sample < ep.samples.size(); ++sample) {
             f << cmb_port << ',' << i_ch << ',' << g << ',' << phase_ck << ',' ;
@@ -149,9 +163,10 @@ int phase_ck = 0;
             f << '\n';
           }
 >>>>>>> Stashed changes
-        }
-      },
-      n_links};
+          }
+        },
+        n_links
+  };
 
 <<<<<<< Updated upstream
   // Makes sure charge injections are turned on for this individual channel
@@ -183,32 +198,33 @@ int phase_ck = 0;
     }
     test_param_builder.add(channel_page, "GAIN_CONV", 7);  // 0 to 7
 =======
-// Makes sure charge injections are turned on for this individual channel
-for (int j = 0; j < 4; j++) {
-  auto ch = cmb_to_ch[cmb_port][j];
-  int link = (ch / 36);
-  auto channel_page = pflib::utility::string_format("CH_%d", ch);
-  auto refvol_page = pflib::utility::string_format("REFERENCEVOLTAGE_%d", link);
-  auto calib_page = pflib::utility::string_format("CALIB_%d", link);
-  auto global_page = pflib::utility::string_format("GLOBALANALOG_%d", link);
-  test_param_builder.add(refvol_page, "CALIB", 0)
-    .add(refvol_page, "CALIB_2V5", 0)
-    .add(refvol_page, "INTCTEST", 1)
-    .add(refvol_page, "CHOICE_CINJ", 0)
-    .add(global_page, "CD", 2)
-    .add(global_page, "CF", 8)
-    .add(global_page, "RF", 10)
-    .add(channel_page, "HIGHRANGE", 0)
-    .add(channel_page, "LOWRANGE", 0)
-    .add(calib_page, "INPUTDAC", 0) //No idea what this should be
-    .add(channel_page, "INPUTDAC", 0) //No idea what this should be
-    .add(global_page, "GAIN_CONV", 1) //0 or 1
-    .add(calib_page, "GAIN_CONV", 4); //0 or 1
-    for (int k = 0; k < 4; k++){
+  // Makes sure charge injections are turned on for this individual channel
+  for (int j = 0; j < 4; j++) {
+    auto ch = cmb_to_ch[cmb_port][j];
+    int link = (ch / 36);
+    auto channel_page = pflib::utility::string_format("CH_%d", ch);
+    auto refvol_page =
+        pflib::utility::string_format("REFERENCEVOLTAGE_%d", link);
+    auto calib_page = pflib::utility::string_format("CALIB_%d", link);
+    auto global_page = pflib::utility::string_format("GLOBALANALOG_%d", link);
+    test_param_builder.add(refvol_page, "CALIB", 0)
+        .add(refvol_page, "CALIB_2V5", 0)
+        .add(refvol_page, "INTCTEST", 1)
+        .add(refvol_page, "CHOICE_CINJ", 0)
+        .add(global_page, "CD", 2)
+        .add(global_page, "CF", 8)
+        .add(global_page, "RF", 10)
+        .add(channel_page, "HIGHRANGE", 0)
+        .add(channel_page, "LOWRANGE", 0)
+        .add(calib_page, "INPUTDAC", 0)    // No idea what this should be
+        .add(channel_page, "INPUTDAC", 0)  // No idea what this should be
+        .add(global_page, "GAIN_CONV", 1)  // 0 or 1
+        .add(calib_page, "GAIN_CONV", 4);  // 0 or 1
+    for (int k = 0; k < 4; k++) {
       auto cm_page = pflib::utility::string_format("CM_%d", link);
-       test_param_builder.add(cm_page, "GAIN_CONV", 4); //0 to 7
+      test_param_builder.add(cm_page, "GAIN_CONV", 4);  // 0 to 7
     }
-    test_param_builder.add(channel_page, "GAIN_CONV", 4); //0 to 7
+    test_param_builder.add(channel_page, "GAIN_CONV", 4);  // 0 to 7
 >>>>>>> Stashed changes
   }
 
@@ -255,34 +271,35 @@ for (int j = 0; j < 4; j++) {
 
 }  // sps_readout
 =======
-int base_trim_inv = pftool::readline_int("Base TRIM_INV value? ", 2);
+  int base_trim_inv = pftool::readline_int("Base TRIM_INV value? ", 2);
 
-for (g = base_trim_inv; g <= base_trim_inv + 2; g++){
+  for (g = base_trim_inv; g <= base_trim_inv + 2; g++) {
+    pflib_log(info) << "TRIM_INV set to = " << g << " (offset +"
+                    << (g - base_trim_inv) << ")";
 
-  pflib_log(info) << "TRIM_INV set to = " << g << " (offset +" << (g - base_trim_inv) << ")";
+    std::map<std::string, std::map<std::string, uint64_t>> page_stat;
 
-  std::map<std::string, std::map<std::string, uint64_t>> page_stat;
+    for (int j = 0; j < 4; j++) {
+      auto ch = cmb_to_ch[cmb_port][j];
+      auto ch_str = pflib::utility::string_format("CH_%d", ch);
+      page_stat[ch_str]["TRIM_INV"] = g;
+    }
+    auto trim_inv_apply = tgt->tempApplyAllROCs(page_stat);
 
-  for (int j = 0; j < 4; j++) {
-    auto ch = cmb_to_ch[cmb_port][j];
-    auto ch_str = pflib::utility::string_format("CH_%d", ch);
-    page_stat[ch_str]["TRIM_INV"] = g;
-  }
-  auto trim_inv_apply =  tgt->tempApplyAllROCs(page_stat);
+    for (phase_ck = start_phase_ck; phase_ck <= end_phase_ck; phase_ck++) {
+      pflib_log(info) << "PHASE_CK = " << phase_ck;
 
-  for (phase_ck = start_phase_ck; phase_ck <= end_phase_ck; phase_ck++){
-    pflib_log(info) << "PHASE_CK = " << phase_ck;
+      auto phase_test_handle =
+          roc.testParameters().add("TOP", "PHASE_CK", phase_ck).apply();
 
-    auto phase_test_handle = roc.testParameters().add("TOP", "PHASE_CK", phase_ck).apply();
+      // tgt->fc().fc_setup_led(start_led_new);
+      tgt->fc().fc_setup_led(tgt_bx);
+      pflib_log(info) << " Target BX  = " << tgt_bx << "\n";
 
-    //tgt->fc().fc_setup_led(start_led_new);
-    tgt->fc().fc_setup_led(tgt_bx);
-    pflib_log(info) << " Target BX  = " << tgt_bx <<"\n";
-
-    daq_run(tgt, "LED", writer, nevents, pftool::state.daq_rate);
-    usleep(10);
+      daq_run(tgt, "LED", writer, nevents, pftool::state.daq_rate);
+      usleep(10);
     }
   }
 
-} //sps_readout
+}  // sps_readout
 >>>>>>> Stashed changes

--- a/app/tool/tasks/SPS_readout.cxx
+++ b/app/tool/tasks/SPS_readout.cxx
@@ -3,28 +3,27 @@
 #include <filesystem>
 #include <nlohmann/json.hpp>
 
-#include "pflib/TRIG.h"
-#include "pflib/packing/Hex.h"
 #include "../daq_run.h"
 #include "../pftool.h"
 #include "pflib/Bias.h"
 #include "pflib/HcalTarget.h"
+#include "pflib/TRIG.h"
+#include "pflib/packing/Hex.h"
 #include "pflib/utility/string_format.h"
 
 ENABLE_LOGGING();
 
 void sps_readout(Target* tgt) {
-
- int cmb_to_ch[16][4] = {
+  int cmb_to_ch[16][4] = {
       {0, 1, 2, 3},     {4, 5, 6, 7},     {9, 10, 11, 12},  {13, 14, 15, 16},
       {18, 19, 20, 21}, {22, 23, 24, 25}, {27, 28, 29, 30}, {31, 32, 33, 34},
       {36, 37, 38, 39}, {40, 41, 42, 43}, {45, 46, 47, 48}, {49, 50, 51, 52},
       {54, 55, 56, 57}, {58, 59, 60, 61}, {63, 64, 65, 66}, {67, 68, 69, 70}};
 
-tgt->setup_run(1, Target::DaqFormat::ECOND_SW_HEADERS, 1);
-pflib::DAQ& daq = tgt->daq();
+  tgt->setup_run(1, Target::DaqFormat::ECOND_SW_HEADERS, 1);
+  pflib::DAQ& daq = tgt->daq();
 
-auto hcalbp = dynamic_cast<pflib::HcalTarget*>(tgt);
+  auto hcalbp = dynamic_cast<pflib::HcalTarget*>(tgt);
   if (!hcalbp) {
     PFEXCEPTION_RAISE("BadTarget",
                       "led_bias_scan only available for Hcal targets");
@@ -36,27 +35,30 @@ auto hcalbp = dynamic_cast<pflib::HcalTarget*>(tgt);
   auto& bias = hcalbp->bias(iboard);
   auto& mapping{tgt->getRocErxMapping()};
 
-int cmb_port = pftool::readline_int("Channel to scan on? ", 0);
-int nevents = pftool::readline_int("How many events per time point? ", 1000);
-int start_led = tgt->fc().fc_get_setup_led();
-int tgt_bx = pftool::readline_int("Target BX? (~22 should be BX = 4) ", start_led);
-int len_bx = pftool::readline_int("Number of BX to scan over? ", 2);
-tgt->fc().setL1AperROR(len_bx);
-//int start_led_new = pftool::readline_int("Calibration L1A offset for LED start point", start_led);
-int n_links = 2 * tgt->nrocs();
+  int cmb_port = pftool::readline_int("Channel to scan on? ", 0);
+  int nevents = pftool::readline_int("How many events per time point? ", 1000);
+  int start_led = tgt->fc().fc_get_setup_led();
+  int tgt_bx =
+      pftool::readline_int("Target BX? (~22 should be BX = 4) ", start_led);
+  int len_bx = pftool::readline_int("Number of BX to scan over? ", 2);
+  tgt->fc().setL1AperROR(len_bx);
+  // int start_led_new = pftool::readline_int("Calibration L1A offset for LED
+  // start point", start_led);
+  int n_links = 2 * tgt->nrocs();
 
-int start_SiPM = bias.readSiPM(cmb_port).value_or(-1);
-int start_LED = bias.readLED(cmb_port).value_or(-1);
-int new_SiPM = pftool::readline_int("SiPM DAC value? ", start_SiPM);
-int new_LED = pftool::readline_int("LED DAC value? ", start_LED);
+  int start_SiPM = bias.readSiPM(cmb_port).value_or(-1);
+  int start_LED = bias.readLED(cmb_port).value_or(-1);
+  int new_SiPM = pftool::readline_int("SiPM DAC value? ", start_SiPM);
+  int new_LED = pftool::readline_int("LED DAC value? ", start_LED);
 
-int start_phase_ck = pftool::readline_int("Starting PHASE_CK value? ", 2);
-int end_phase_ck = pftool::readline_int("Ending PHASE_CK value? ", 2);
-int trim_inv = pftool::readline_int("TRIM_INV value? ", 2);
-int trim_range = pftool::readline_int("Range of TRIM_INV values to scan over for convolution? ", 1);
+  int start_phase_ck = pftool::readline_int("Starting PHASE_CK value? ", 2);
+  int end_phase_ck = pftool::readline_int("Ending PHASE_CK value? ", 2);
+  int trim_inv = pftool::readline_int("TRIM_INV value? ", 2);
+  int trim_range = pftool::readline_int(
+      "Range of TRIM_INV values to scan over for convolution? ", 1);
 
-bias.setSiPM(cmb_port, new_SiPM);
-bias.setLED(cmb_port, new_LED);
+  bias.setSiPM(cmb_port, new_SiPM);
+  bias.setLED(cmb_port, new_LED);
 
   pflib::ROC roc{tgt->roc(iboard)};
 
@@ -64,10 +66,10 @@ bias.setLED(cmb_port, new_LED);
   auto test_param_builder = roc.testParameters();
   fname = pftool::readline_path("SPS-scan", ".csv");
 
-int g = 0;
-int phase_ck = 0;
+  int g = 0;
+  int phase_ck = 0;
 
- DecodeAndWriteToCSV writer{
+  DecodeAndWriteToCSV writer{
       fname,
       [&](std::ofstream& f) {
         nlohmann::ordered_json header;
@@ -80,81 +82,82 @@ int phase_ck = 0;
         for (int j = 0; j < 4; j++) {
           auto ch = cmb_to_ch[cmb_port][j];
           auto [i_erx, i_ch] = mapping.toErxChannel(iboard, ch);
-          f << cmb_port << ',' << i_ch << ',' << g << ',' << phase_ck << ','  << new_SiPM  << ','  << new_LED  << ',' ;
+          f << cmb_port << ',' << i_ch << ',' << g << ',' << phase_ck << ','
+            << new_SiPM << ',' << new_LED << ',';
           ep.samples[ep.i_soi].channel(i_erx, i_ch).to_csv(f);
           f << '\n';
         }
       },
       n_links};
 
-// Makes sure charge injections are turned on for this individual channel
-for (int j = 0; j < 4; j++) {
-  auto ch = cmb_to_ch[cmb_port][j];
-  int link = (ch / 36);
-  auto channel_page = pflib::utility::string_format("CH_%d", ch);
-  auto refvol_page = pflib::utility::string_format("REFERENCEVOLTAGE_%d", link);
-  auto calib_page = pflib::utility::string_format("CALIB_%d", link);
-  auto global_page = pflib::utility::string_format("GLOBALANALOG_%d", link);
-  test_param_builder.add(refvol_page, "CALIB", 0)
-    .add(refvol_page, "CALIB_2V5", 0)
-    .add(refvol_page, "INTCTEST", 1)
-    .add(refvol_page, "CHOICE_CINJ", 0)
-    .add(global_page, "CD", 2)
-    .add(global_page, "CF", 8)
-    .add(global_page, "RF", 10)
-    .add(channel_page, "HIGHRANGE", 0)
-    .add(channel_page, "LOWRANGE", 0)
-    .add(calib_page, "INPUTDAC", 32) //No idea what this should be (MAXES out at 63)
-    .add(channel_page, "INPUTDAC", 32) //No idea what this should be
-    .add(global_page, "GAIN_CONV", 1) //0 or 1
-    .add(calib_page, "GAIN_CONV", 7); //0 or 1
-    for (int k = 0; k < 4; k++){
+  // Makes sure charge injections are turned on for this individual channel
+  for (int j = 0; j < 4; j++) {
+    auto ch = cmb_to_ch[cmb_port][j];
+    int link = (ch / 36);
+    auto channel_page = pflib::utility::string_format("CH_%d", ch);
+    auto refvol_page =
+        pflib::utility::string_format("REFERENCEVOLTAGE_%d", link);
+    auto calib_page = pflib::utility::string_format("CALIB_%d", link);
+    auto global_page = pflib::utility::string_format("GLOBALANALOG_%d", link);
+    test_param_builder.add(refvol_page, "CALIB", 0)
+        .add(refvol_page, "CALIB_2V5", 0)
+        .add(refvol_page, "INTCTEST", 1)
+        .add(refvol_page, "CHOICE_CINJ", 0)
+        .add(global_page, "CD", 2)
+        .add(global_page, "CF", 8)
+        .add(global_page, "RF", 10)
+        .add(channel_page, "HIGHRANGE", 0)
+        .add(channel_page, "LOWRANGE", 0)
+        .add(calib_page, "INPUTDAC",
+             32)  // No idea what this should be (MAXES out at 63)
+        .add(channel_page, "INPUTDAC", 32)  // No idea what this should be
+        .add(global_page, "GAIN_CONV", 1)   // 0 or 1
+        .add(calib_page, "GAIN_CONV", 7);   // 0 or 1
+    for (int k = 0; k < 4; k++) {
       auto cm_page = pflib::utility::string_format("CM_%d", link);
-       test_param_builder.add(cm_page, "GAIN_CONV", 7); //0 to 7
+      test_param_builder.add(cm_page, "GAIN_CONV", 7);  // 0 to 7
     }
-    test_param_builder.add(channel_page, "GAIN_CONV", 7); //0 to 7
+    test_param_builder.add(channel_page, "GAIN_CONV", 7);  // 0 to 7
   }
 
   auto test_param_handle = test_param_builder.apply();
 
+  for (g = (trim_inv - trim_range); g < (trim_inv + trim_range + 1); g++) {
+    pflib_log(info) << "TRIM_INV set to = " << g;
 
-for (g = (trim_inv - trim_range); g < (trim_inv + trim_range + 1); g++){
+    std::map<std::string, std::map<std::string, uint64_t>> page_stat;
 
-  pflib_log(info) << "TRIM_INV set to = " << g;
+    for (int j = 0; j < 4; j++) {
+      auto ch = cmb_to_ch[cmb_port][j];
+      auto ch_str = pflib::utility::string_format("CH_%d", ch);
+      page_stat[ch_str]["TRIM_INV"] = g;
+    }
+    auto trim_inv_apply = tgt->tempApplyAllROCs(page_stat);
 
-  std::map<std::string, std::map<std::string, uint64_t>> page_stat;
+    for (phase_ck = start_phase_ck; phase_ck <= end_phase_ck; phase_ck++) {
+      pflib_log(info) << "PHASE_CK = " << phase_ck;
 
-  for (int j = 0; j < 4; j++) {
-    auto ch = cmb_to_ch[cmb_port][j];
-    auto ch_str = pflib::utility::string_format("CH_%d", ch);
-    page_stat[ch_str]["TRIM_INV"] = g;
-  }
-  auto trim_inv_apply =  tgt->tempApplyAllROCs(page_stat);
+      auto phase_test_handle =
+          roc.testParameters().add("TOP", "PHASE_CK", phase_ck).apply();
 
-  for (phase_ck = start_phase_ck; phase_ck <= end_phase_ck; phase_ck++){
-    pflib_log(info) << "PHASE_CK = " << phase_ck;
+      bool enable_l1a_follow;
+      // int central_charge_to_l1a = tgt->fc().fc_get_setup_led();
 
-    auto phase_test_handle = roc.testParameters().add("TOP", "PHASE_CK", phase_ck).apply();
+      // tgt->fc().fc_setup_led(start_led_new);
+      tgt->fc().fc_setup_led(tgt_bx);
+      pflib_log(info) << " Target BX  = " << tgt_bx << "\n";
 
-    bool enable_l1a_follow;
-    //int central_charge_to_l1a = tgt->fc().fc_get_setup_led();
-
-    //tgt->fc().fc_setup_led(start_led_new);
-    tgt->fc().fc_setup_led(tgt_bx);
-    pflib_log(info) << " Target BX  = " << tgt_bx <<"\n";
-
-    daq_run(tgt, "LED", writer, nevents, pftool::state.daq_rate);
-    usleep(10);
-    //auto data = buffer.get_buffer();
-    //auto mapping = tgt->getRocErxMapping();
-    //auto [i_erx, i_ch] = mapping.toErxChannel(i_roc, 17);
-    //for (std::size_t i{0}; i < data.size(); i++) {
-      //for (int j = 0; j < nr_bx; j++) {
-        //adcs[j].push_back(data[i].samples.at(j).channel(i_erx, i_ch).adc());
+      daq_run(tgt, "LED", writer, nevents, pftool::state.daq_rate);
+      usleep(10);
+      // auto data = buffer.get_buffer();
+      // auto mapping = tgt->getRocErxMapping();
+      // auto [i_erx, i_ch] = mapping.toErxChannel(i_roc, 17);
+      // for (std::size_t i{0}; i < data.size(); i++) {
+      // for (int j = 0; j < nr_bx; j++) {
+      // adcs[j].push_back(data[i].samples.at(j).channel(i_erx, i_ch).adc());
       //}
-    //}
-
+      //}
     }
   }
 
-} //sps_readout
+}  // sps_readout

--- a/app/tool/tasks/SPS_readout.h
+++ b/app/tool/tasks/SPS_readout.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../pftool.h"
+
+/**
+ * TASKS.SPS_SCAN
+ *
+ * Used to scan different SiPM or LED DAC values/biases.
+ * Both can either be varied over a range, or kept constant if the same value is
+ * entered for the start and stop value. One can choose how many ports have CMBs
+ * connected An LED flash on one CMB flashes into four HGCROC channels
+ * simultaneously, thus the pulses of all four respective channels are recorded
+ * in the csv file.
+ *
+ */
+void sps_readout(Target* tgt);

--- a/app/tool/tasks/tasks.cxx
+++ b/app/tool/tasks/tasks.cxx
@@ -24,6 +24,7 @@
 #include "setup/align_econ_lpgbt.h"
 #include "setup/align_phase_word.h"
 #include "setup/check_lpgbt_backend.h"
+#include "SPS_readout.h"
 #include "toa_scan.h"
 #include "toa_vref_scan.h"
 #include "tot_scan.h"
@@ -79,7 +80,8 @@ auto menu_tasks =
                "calibrate TRIM_TOA parameters for each channel", trim_toa_scan)
         ->line("TOA_SCAN", "calibrate TRIM_TOA parameters for each channel",
                toa_scan)
-        ->line("LED_BIAS_SCAN", "Sweeps SiPM and LED DACs", led_bias_scan);
+        ->line("LED_BIAS_SCAN", "Sweeps SiPM and LED DACs", led_bias_scan)
+        ->line("SPS_READOUT", "Take data of a photospectrum on one bunch crossing", sps_readout);
 
 auto menu_expert_tasks =
     menu_tasks->submenu("EXPERT", "low-level but complicated tasks")

--- a/app/tool/tasks/tasks.cxx
+++ b/app/tool/tasks/tasks.cxx
@@ -5,6 +5,7 @@
  */
 
 #include "../pftool.h"
+#include "SPS_readout.h"
 #include "channel_wise_calib_scan.h"
 #include "charge_timescan.h"
 #include "examine_phase.h"
@@ -24,7 +25,6 @@
 #include "setup/align_econ_lpgbt.h"
 #include "setup/align_phase_word.h"
 #include "setup/check_lpgbt_backend.h"
-#include "SPS_readout.h"
 #include "toa_scan.h"
 #include "toa_vref_scan.h"
 #include "tot_scan.h"
@@ -81,7 +81,9 @@ auto menu_tasks =
         ->line("TOA_SCAN", "calibrate TRIM_TOA parameters for each channel",
                toa_scan)
         ->line("LED_BIAS_SCAN", "Sweeps SiPM and LED DACs", led_bias_scan)
-        ->line("SPS_READOUT", "Take data of a photospectrum on one bunch crossing", sps_readout);
+        ->line("SPS_READOUT",
+               "Take data of a photospectrum on one bunch crossing",
+               sps_readout);
 
 auto menu_expert_tasks =
     menu_tasks->submenu("EXPERT", "low-level but complicated tasks")


### PR DESCRIPTION
This has been our attempt at UVA to make a scan that is able to take data from a large amount of LED daq_runs (measuring over multiple bunch crossings and phase_ck values).
 - First the SPS_READOUT command takes lots of input values (LED_DAC, SiPM_DAC, BX, etc...) and applies them to the ROC and HDMI port of interest. Next it scans using a LED scan and writes the data to a CSV file
 - This CSV file is then interpreted and made into histograms with the SPS_histogram.py file (See pic below)
<img width="2400" height="1500" alt="image" src="https://github.com/user-attachments/assets/e8cbb3bd-5951-4581-8069-3c77d59f4690" />
 - To run this correctly:  before you run the SPS_READOUT command please find a correct TRIM_INV value to set the port to (my stratedgy is to take one of the values found by running LOCAL_PEDESTALS and then using it for all of them, but only really focusing on the channel that the TRIM_INV value corresponds to (Could be updated in the future), this is done to attempt to lower the spread of values). Next you run the SPS_READOUT command. The settings that we have been setting at uva with multiple ROCs attached to our backplane have been:

1. 1000-10000 events per time point
2. 22 as the Target bunch crossing
3. Number of bunch crossing to scan over = 2
4. SiPM_DAC = 3850
5. LED_DAC = 3000
6. Only doing the PHASE_CK value of 2 and no other values
7. TRIM_INV of 9 (it works for one of the channels)
9. Range of TRIM_INV values: 1 (used for DNL later)
10. inputdac = 32 (guess)

 - Once you have taken a run go to the ana/LED directory and run "python3 SPS_histogram.py /full/path/" and it will produce the desired graphs
 - Please note: this is only a start, at UVA we have had very little success actually getting this to work with regards to getting a substantive spectrum for the photons interacting with the SiPM, there are many settings that we have not confirmed are correct. Most of these come from the CSM documentation that we could find and some previous experience in the LED_BIAS_SCAN settings. Any additional work on alternative settings would greatly be appreciated, but I feel that it is focus on what the correct value for inputdac is and what the biasing should be for this scan.
 - NOTE: this is partially incomplete and I have not added a functionality to add all of the data from a single run that are on different bunch crossings together in any way, so I believe that the function just records them as entries in the CSV file, need to update this.